### PR TITLE
Unity 18 round game info tiles remaining seat wind score UI

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -813,6 +813,7 @@ Transform:
   - {fileID: 994526682}
   - {fileID: 1781581991}
   - {fileID: 849848557}
+  - {fileID: 1393835955}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &665667694
@@ -1062,7 +1063,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1075158129}
   m_Layer: 0
-  m_Name: ---UIScoreArea
+  m_Name: ---UI-Info-Score-Seat-Area
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1115,8 +1116,8 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 955096232}
-  - {fileID: 1427846889}
   - {fileID: 204941200}
+  - {fileID: 1427846889}
   - {fileID: 1732554149}
   - {fileID: 1275787565}
   - {fileID: 1914367656}
@@ -1318,7 +1319,7 @@ GameObject:
   - component: {fileID: 1275787567}
   - component: {fileID: 1275787566}
   m_Layer: 5
-  m_Name: GameObject
+  m_Name: TilesRemaining
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -1461,6 +1462,60 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1323078176}
   m_CullTransparentMesh: 1
+--- !u!1 &1393835954
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1393835955}
+  - component: {fileID: 1393835956}
+  m_Layer: 0
+  m_Name: RoundInfoUIManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1393835955
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393835954}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 1131.355, y: 694.2278, z: -177.23026}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 646768857}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1393835956
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1393835954}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 80ba28bf3a74440bb912eeb23b0522a4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  textRoundInfo: {fileID: 253960766}
+  textTilesRemaining: {fileID: 1555599385}
+  textSeatE: {fileID: 1254275887}
+  textSeatS: {fileID: 1444593827}
+  textSeatW: {fileID: 1426389795}
+  textSeatN: {fileID: 2145694313}
+  textScoreE: {fileID: 1613068445}
+  textScoreS: {fileID: 2082270203}
+  textScoreW: {fileID: 1323078178}
+  textScoreN: {fileID: 1512968277}
 --- !u!1 &1426389793
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -335,6 +335,131 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &204941199
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 204941200}
+  - component: {fileID: 204941201}
+  m_Layer: 5
+  m_Name: S
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &204941200
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 204941199}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1444593826}
+  - {fileID: 2082270202}
+  m_Father: {fileID: 1170345277}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 135, y: 0}
+  m_SizeDelta: {x: -270, y: -160}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &204941201
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 204941199}
+  m_CullTransparentMesh: 1
+--- !u!1 &253960764
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 253960765}
+  - component: {fileID: 253960767}
+  - component: {fileID: 253960766}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &253960765
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 253960764}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1914367656}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &253960766
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 253960764}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Game Info
+--- !u!222 &253960767
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 253960764}
+  m_CullTransparentMesh: 1
 --- !u!1 &285614005
 GameObject:
   m_ObjectHideFlags: 0
@@ -767,7 +892,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!4 &798848189
 Transform:
   m_ObjectHideFlags: 0
@@ -830,6 +955,52 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   discardManager: {fileID: 1781581992}
   discardButton: {fileID: 618156008}
+--- !u!1 &955096231
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 955096232}
+  - component: {fileID: 955096233}
+  m_Layer: 5
+  m_Name: E
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &955096232
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955096231}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1254275886}
+  - {fileID: 1613068444}
+  m_Father: {fileID: 1170345277}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -134}
+  m_SizeDelta: {x: -160, y: -272}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &955096233
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 955096231}
+  m_CullTransparentMesh: 1
 --- !u!1 &994526680
 GameObject:
   m_ObjectHideFlags: 0
@@ -942,13 +1113,19 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
-  m_Children: []
+  m_Children:
+  - {fileID: 955096232}
+  - {fileID: 1427846889}
+  - {fileID: 204941200}
+  - {fileID: 1732554149}
+  - {fileID: 1275787565}
+  - {fileID: 1914367656}
   m_Father: {fileID: 152533179}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
   m_AnchoredPosition: {x: 0, y: 120}
-  m_SizeDelta: {x: 340, y: 300}
+  m_SizeDelta: {x: 300, y: 300}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1170345278
 MonoBehaviour:
@@ -963,14 +1140,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   m_Material: {fileID: 0}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Color: {r: 0.05660379, g: 0.05660379, b: 0.05660379, a: 1}
   m_RaycastTarget: 0
   m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
   m_Maskable: 1
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 4130640169021434097, guid: 4db6aa40c4f324e5db8b5176276259a8, type: 3}
+  m_Sprite: {fileID: 0}
   m_Type: 0
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -1019,6 +1196,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 522875599}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1254275885
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1254275886}
+  - component: {fileID: 1254275888}
+  - component: {fileID: 1254275887}
+  m_Layer: 5
+  m_Name: SeatWind
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1254275886
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1254275885}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 955096232}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -35, y: 0}
+  m_SizeDelta: {x: -70, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1254275887
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1254275885}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: E
+--- !u!222 &1254275888
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1254275885}
+  m_CullTransparentMesh: 1
 --- !u!1 &1255911353
 GameObject:
   m_ObjectHideFlags: 0
@@ -1050,6 +1306,367 @@ Transform:
   m_Children: []
   m_Father: {fileID: 42178009}
   m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
+--- !u!1 &1275787564
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1275787565}
+  - component: {fileID: 1275787567}
+  - component: {fileID: 1275787566}
+  m_Layer: 5
+  m_Name: GameObject
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1275787565
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275787564}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1555599384}
+  m_Father: {fileID: 1170345277}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -50}
+  m_SizeDelta: {x: -200, y: -200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1275787566
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275787564}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1275787567
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1275787564}
+  m_CullTransparentMesh: 1
+--- !u!1 &1323078176
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1323078177}
+  - component: {fileID: 1323078179}
+  - component: {fileID: 1323078178}
+  m_Layer: 5
+  m_Name: Score
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1323078177
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323078176}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1427846889}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 35, y: 0}
+  m_SizeDelta: {x: -70, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1323078178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323078176}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 99
+--- !u!222 &1323078179
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323078176}
+  m_CullTransparentMesh: 1
+--- !u!1 &1426389793
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1426389794}
+  - component: {fileID: 1426389796}
+  - component: {fileID: 1426389795}
+  m_Layer: 5
+  m_Name: SeatWind
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1426389794
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1426389793}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1427846889}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -35, y: 0}
+  m_SizeDelta: {x: -70, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1426389795
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1426389793}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'W
+
+'
+--- !u!222 &1426389796
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1426389793}
+  m_CullTransparentMesh: 1
+--- !u!1 &1427846888
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1427846889}
+  - component: {fileID: 1427846890}
+  m_Layer: 5
+  m_Name: W
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1427846889
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427846888}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1426389794}
+  - {fileID: 1323078177}
+  m_Father: {fileID: 1170345277}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 136}
+  m_SizeDelta: {x: -160, y: -272}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1427846890
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1427846888}
+  m_CullTransparentMesh: 1
+--- !u!1 &1444593825
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1444593826}
+  - component: {fileID: 1444593828}
+  - component: {fileID: 1444593827}
+  m_Layer: 5
+  m_Name: SeatWind
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1444593826
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1444593825}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 204941200}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 35}
+  m_SizeDelta: {x: 0, y: -70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1444593827
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1444593825}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: S
+--- !u!222 &1444593828
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1444593825}
+  m_CullTransparentMesh: 1
 --- !u!1 &1471120613
 GameObject:
   m_ObjectHideFlags: 0
@@ -1082,6 +1699,243 @@ Transform:
   - {fileID: 618156007}
   m_Father: {fileID: 1668335932}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1512968275
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1512968276}
+  - component: {fileID: 1512968278}
+  - component: {fileID: 1512968277}
+  m_Layer: 5
+  m_Name: Score
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1512968276
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512968275}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1732554149}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -35}
+  m_SizeDelta: {x: 0, y: -70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1512968277
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512968275}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 88
+--- !u!222 &1512968278
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1512968275}
+  m_CullTransparentMesh: 1
+--- !u!1 &1555599383
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1555599384}
+  - component: {fileID: 1555599386}
+  - component: {fileID: 1555599385}
+  m_Layer: 5
+  m_Name: Text (Legacy)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1555599384
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555599383}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1275787565}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: -20}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1555599385
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555599383}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: Tiles Remaining
+--- !u!222 &1555599386
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555599383}
+  m_CullTransparentMesh: 1
+--- !u!1 &1613068443
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1613068444}
+  - component: {fileID: 1613068446}
+  - component: {fileID: 1613068445}
+  m_Layer: 5
+  m_Name: Score
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1613068444
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613068443}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 955096232}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 35, y: 0}
+  m_SizeDelta: {x: -70, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1613068445
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613068443}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 99
+--- !u!222 &1613068446
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1613068443}
+  m_CullTransparentMesh: 1
 --- !u!1 &1668335927
 GameObject:
   m_ObjectHideFlags: 0
@@ -1305,6 +2159,52 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1697536077}
+  m_CullTransparentMesh: 1
+--- !u!1 &1732554148
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1732554149}
+  - component: {fileID: 1732554150}
+  m_Layer: 5
+  m_Name: N
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1732554149
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732554148}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2145694312}
+  - {fileID: 1512968276}
+  m_Father: {fileID: 1170345277}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: -135, y: 0}
+  m_SizeDelta: {x: -270, y: -160}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &1732554150
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1732554148}
   m_CullTransparentMesh: 1
 --- !u!1 &1781581990
 GameObject:
@@ -1596,6 +2496,82 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1806466145}
   m_CullTransparentMesh: 0
+--- !u!1 &1914367655
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1914367656}
+  - component: {fileID: 1914367658}
+  - component: {fileID: 1914367657}
+  m_Layer: 5
+  m_Name: GameInfo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1914367656
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1914367655}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 253960765}
+  m_Father: {fileID: 1170345277}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 50}
+  m_SizeDelta: {x: -200, y: -200}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1914367657
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1914367655}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1914367658
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1914367655}
+  m_CullTransparentMesh: 1
 --- !u!1 &2025298132
 GameObject:
   m_ObjectHideFlags: 0
@@ -1627,6 +2603,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 42178009}
   m_LocalEulerAnglesHint: {x: -90, y: -90, z: 0}
+--- !u!1 &2082270201
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2082270202}
+  - component: {fileID: 2082270204}
+  - component: {fileID: 2082270203}
+  m_Layer: 5
+  m_Name: Score
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2082270202
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082270201}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 204941200}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: -35}
+  m_SizeDelta: {x: 0, y: -70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2082270203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082270201}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 88
+--- !u!222 &2082270204
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2082270201}
+  m_CullTransparentMesh: 1
 --- !u!1 &2099223880
 GameObject:
   m_ObjectHideFlags: 0
@@ -1658,6 +2713,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 42178009}
   m_LocalEulerAnglesHint: {x: -90, y: 90, z: 0}
+--- !u!1 &2145694311
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2145694312}
+  - component: {fileID: 2145694314}
+  - component: {fileID: 2145694313}
+  m_Layer: 5
+  m_Name: SeatWind
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2145694312
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2145694311}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1732554149}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 35}
+  m_SizeDelta: {x: 0, y: -70}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2145694313
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2145694311}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 20
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 2
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: N
+--- !u!222 &2145694314
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2145694311}
+  m_CullTransparentMesh: 1
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/GamePage/RoundInfoUIManager.cs
+++ b/Assets/Scripts/GamePage/RoundInfoUIManager.cs
@@ -1,28 +1,56 @@
 using UnityEngine;
 using UnityEngine.UI;
+using System.Collections.Generic;
 
 public class RoundInfoUIManager : MonoBehaviour
 {
     [Header("UI Text Components")]
-    [SerializeField] private Text textRoundInfo;
-    [SerializeField] private Text textTilesRemaining;
-    [SerializeField] private Text textWindE;
-    [SerializeField] private Text textWindS;
-    [SerializeField] private Text textWindW;
-    [SerializeField] private Text textWindN;
+    [SerializeField] private Text textRoundInfo;       // 현재 국 정보
+    [SerializeField] private Text textTilesRemaining;  // 남은 패
 
-    // 임시 변수 (서버에서 받을 예정)
-    private int tilesRemaining = 99;
-    private string currentRound = "E1";  // 예: 동1국
+    [Header("Seat Label Text")]
+    [SerializeField] private Text textSeatE;
+    [SerializeField] private Text textSeatS;
+    [SerializeField] private Text textSeatW;
+    [SerializeField] private Text textSeatN;
+
+    [Header("Seat Score Text")]
+    [SerializeField] private Text textScoreE;
+    [SerializeField] private Text textScoreS;
+    [SerializeField] private Text textScoreW;
+    [SerializeField] private Text textScoreN;
+
+    // 임시 데이터
+    private int tilesRemaining = 130;   // 남은 패 130개 고정
+    private string currentRound = "E1"; // 예: 동1국
+
+    // 자리와 점수를 각각 Dictionary로 관리
+    private Dictionary<PlayerSeat, string> seatLabels = new Dictionary<PlayerSeat, string>();
+    private Dictionary<PlayerSeat, int> seatScores = new Dictionary<PlayerSeat, int>();
 
     private void Start()
     {
-        // 초기 UI 업데이트
+        // Mock(더미) 데이터 초기화
+        tilesRemaining = 130;      // 고정
+        currentRound = "E1";       // 예시 국 정보
+
+        // 좌석 라벨
+        seatLabels[PlayerSeat.E] = "E"; // 실제로는 "동" 등으로 쓸 수도 있음
+        seatLabels[PlayerSeat.S] = "S";
+        seatLabels[PlayerSeat.W] = "W";
+        seatLabels[PlayerSeat.N] = "N";
+
+        // 각 좌석에 임의 점수
+        seatScores[PlayerSeat.E] = Random.Range(1, 400);
+        seatScores[PlayerSeat.S] = Random.Range(1, 400);
+        seatScores[PlayerSeat.W] = Random.Range(1, 400);
+        seatScores[PlayerSeat.N] = Random.Range(1, 400);
+
         UpdateUI();
     }
 
     /// <summary>
-    /// 서버 정보 수신 후 갱신할 때 호출
+    /// 국 정보(E1, E2...) 변경 시
     /// </summary>
     public void SetRoundInfo(string roundInfo)
     {
@@ -30,23 +58,66 @@ public class RoundInfoUIManager : MonoBehaviour
         UpdateUI();
     }
 
+    /// <summary>
+    /// 남은 패 갱신 시
+    /// </summary>
     public void SetTilesRemaining(int count)
     {
         tilesRemaining = count;
         UpdateUI();
     }
 
+    /// <summary>
+    /// 좌석 라벨(문자열) 설정
+    /// </summary>
+    public void SetSeatLabel(PlayerSeat seat, string label)
+    {
+        seatLabels[seat] = label;
+        UpdateUI();
+    }
+
+    /// <summary>
+    /// 좌석 점수(int) 설정
+    /// </summary>
+    public void SetSeatScore(PlayerSeat seat, int score)
+    {
+        seatScores[seat] = score;
+        UpdateUI();
+    }
+
     private void UpdateUI()
     {
+        // 국 정보
         if (textRoundInfo != null)
             textRoundInfo.text = $"Round: {currentRound}";
 
+        // 남은 패
         if (textTilesRemaining != null)
             textTilesRemaining.text = $"Tiles Remaining: {tilesRemaining}";
 
-        // 필요하다면 자리바람(Seat Wind)와 점수도 업데이트
-        // ex) textWindE.text = "E\nScore: 25000";
-        //     textWindS.text = "S\nScore: 24000";
-        // ...
+        // --- 동(E) ---
+        if (textSeatE != null && seatLabels.ContainsKey(PlayerSeat.E))
+            textSeatE.text = seatLabels[PlayerSeat.E];
+        if (textScoreE != null && seatScores.ContainsKey(PlayerSeat.E))
+            textScoreE.text = seatScores[PlayerSeat.E].ToString();
+
+        // --- 남(S) ---
+        if (textSeatS != null && seatLabels.ContainsKey(PlayerSeat.S))
+            textSeatS.text = seatLabels[PlayerSeat.S];
+        if (textScoreS != null && seatScores.ContainsKey(PlayerSeat.S))
+            textScoreS.text = seatScores[PlayerSeat.S].ToString();
+
+        // --- 서(W) ---
+        if (textSeatW != null && seatLabels.ContainsKey(PlayerSeat.W))
+            textSeatW.text = seatLabels[PlayerSeat.W];
+        if (textScoreW != null && seatScores.ContainsKey(PlayerSeat.W))
+            textScoreW.text = seatScores[PlayerSeat.W].ToString();
+
+        // --- 북(N) ---
+        if (textSeatN != null && seatLabels.ContainsKey(PlayerSeat.N))
+            textSeatN.text = seatLabels[PlayerSeat.N];
+        if (textScoreN != null && seatScores.ContainsKey(PlayerSeat.N))
+            textScoreN.text = seatScores[PlayerSeat.N].ToString();
     }
 }
+

--- a/Assets/Scripts/GamePage/RoundInfoUIManager.cs
+++ b/Assets/Scripts/GamePage/RoundInfoUIManager.cs
@@ -1,0 +1,52 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+public class RoundInfoUIManager : MonoBehaviour
+{
+    [Header("UI Text Components")]
+    [SerializeField] private Text textRoundInfo;
+    [SerializeField] private Text textTilesRemaining;
+    [SerializeField] private Text textWindE;
+    [SerializeField] private Text textWindS;
+    [SerializeField] private Text textWindW;
+    [SerializeField] private Text textWindN;
+
+    // 임시 변수 (서버에서 받을 예정)
+    private int tilesRemaining = 99;
+    private string currentRound = "E1";  // 예: 동1국
+
+    private void Start()
+    {
+        // 초기 UI 업데이트
+        UpdateUI();
+    }
+
+    /// <summary>
+    /// 서버 정보 수신 후 갱신할 때 호출
+    /// </summary>
+    public void SetRoundInfo(string roundInfo)
+    {
+        currentRound = roundInfo;
+        UpdateUI();
+    }
+
+    public void SetTilesRemaining(int count)
+    {
+        tilesRemaining = count;
+        UpdateUI();
+    }
+
+    private void UpdateUI()
+    {
+        if (textRoundInfo != null)
+            textRoundInfo.text = $"Round: {currentRound}";
+
+        if (textTilesRemaining != null)
+            textTilesRemaining.text = $"Tiles Remaining: {tilesRemaining}";
+
+        // 필요하다면 자리바람(Seat Wind)와 점수도 업데이트
+        // ex) textWindE.text = "E\nScore: 25000";
+        //     textWindS.text = "S\nScore: 24000";
+        // ...
+    }
+}

--- a/Assets/Scripts/GamePage/RoundInfoUIManager.cs
+++ b/Assets/Scripts/GamePage/RoundInfoUIManager.cs
@@ -4,43 +4,54 @@ using System.Collections.Generic;
 
 public class RoundInfoUIManager : MonoBehaviour
 {
-    [Header("UI Text Components")]
-    [SerializeField] private Text textRoundInfo;       // 현재 국 정보
-    [SerializeField] private Text textTilesRemaining;  // 남은 패
+    [Header("국 정보 및 남은 패")]
+    [SerializeField] private Text textRoundInfo;       // 현재 국 정보 표시 (예: E1)
+    [SerializeField] private Text textTilesRemaining;    // 남은 패 수 표시 (예: 130)
 
-    [Header("Seat Label Text")]
+    [Header("좌석 라벨 Text 컴포넌트")]
     [SerializeField] private Text textSeatE;
     [SerializeField] private Text textSeatS;
     [SerializeField] private Text textSeatW;
     [SerializeField] private Text textSeatN;
 
-    [Header("Seat Score Text")]
+    [Header("좌석 점수 Text 컴포넌트")]
     [SerializeField] private Text textScoreE;
     [SerializeField] private Text textScoreS;
     [SerializeField] private Text textScoreW;
     [SerializeField] private Text textScoreN;
 
-    // 임시 데이터
-    private int tilesRemaining = 130;   // 남은 패 130개 고정
-    private string currentRound = "E1"; // 예: 동1국
+    // UI Text 컴포넌트를 좌석별로 관리하는 Dictionary
+    private Dictionary<PlayerSeat, Text> seatLabelDict = new Dictionary<PlayerSeat, Text>();
+    private Dictionary<PlayerSeat, Text> seatScoreDict = new Dictionary<PlayerSeat, Text>();
 
-    // 자리와 점수를 각각 Dictionary로 관리
+    // 서버에서 받아올 데이터를 모의하는 Dictionary (좌석 라벨 및 점수)
     private Dictionary<PlayerSeat, string> seatLabels = new Dictionary<PlayerSeat, string>();
     private Dictionary<PlayerSeat, int> seatScores = new Dictionary<PlayerSeat, int>();
 
+    // 남은 패와 현재 국 정보 (서버에서 받아올 값)
+    private int tilesRemaining = 130;   // 남은 패 130개 고정
+    private string currentRound = "E1"; // 예시 국 정보
+
     private void Start()
     {
-        // Mock(더미) 데이터 초기화
-        tilesRemaining = 130;      // 고정
-        currentRound = "E1";       // 예시 국 정보
+        // UI 컴포넌트를 Dictionary에 등록
+        seatLabelDict[PlayerSeat.E] = textSeatE;
+        seatLabelDict[PlayerSeat.S] = textSeatS;
+        seatLabelDict[PlayerSeat.W] = textSeatW;
+        seatLabelDict[PlayerSeat.N] = textSeatN;
 
-        // 좌석 라벨
-        seatLabels[PlayerSeat.E] = "E"; // 실제로는 "동" 등으로 쓸 수도 있음
+        seatScoreDict[PlayerSeat.E] = textScoreE;
+        seatScoreDict[PlayerSeat.S] = textScoreS;
+        seatScoreDict[PlayerSeat.W] = textScoreW;
+        seatScoreDict[PlayerSeat.N] = textScoreN;
+
+        // Mock 데이터 초기화
+        seatLabels[PlayerSeat.E] = "E";
         seatLabels[PlayerSeat.S] = "S";
         seatLabels[PlayerSeat.W] = "W";
         seatLabels[PlayerSeat.N] = "N";
 
-        // 각 좌석에 임의 점수
+        // 각 좌석 점수는 10,000 ~ 40,000 사이의 랜덤 값으로 설정 (여기서는 예시로 1 ~ 400 사용)
         seatScores[PlayerSeat.E] = Random.Range(1, 400);
         seatScores[PlayerSeat.S] = Random.Range(1, 400);
         seatScores[PlayerSeat.W] = Random.Range(1, 400);
@@ -50,74 +61,57 @@ public class RoundInfoUIManager : MonoBehaviour
     }
 
     /// <summary>
-    /// 국 정보(E1, E2...) 변경 시
+    /// UI를 업데이트하는 메서드 (국 정보, 남은 패, 좌석 라벨, 좌석 점수를 갱신)
     /// </summary>
+    private void UpdateUI()
+    {
+        if (textRoundInfo != null)
+            textRoundInfo.text = $"Round: {currentRound}";
+
+        if (textTilesRemaining != null)
+            textTilesRemaining.text = $"Tiles Remaining: {tilesRemaining}";
+
+        // 좌석 라벨 업데이트 using TryGetValue
+        foreach (var seat in seatLabelDict.Keys)
+        {
+            if (seatLabelDict[seat] != null && seatLabels.TryGetValue(seat, out string label))
+            {
+                seatLabelDict[seat].text = label;
+            }
+        }
+
+        // 좌석 점수 업데이트 using TryGetValue
+        foreach (var seat in seatScoreDict.Keys)
+        {
+            if (seatScoreDict[seat] != null && seatScores.TryGetValue(seat, out int score))
+            {
+                seatScoreDict[seat].text = score.ToString();
+            }
+        }
+    }
+
+    // 아래의 Set 메서드들은 서버와 연동 시 호출되어 데이터를 갱신할 때 사용할 수 있습니다.
     public void SetRoundInfo(string roundInfo)
     {
         currentRound = roundInfo;
         UpdateUI();
     }
 
-    /// <summary>
-    /// 남은 패 갱신 시
-    /// </summary>
     public void SetTilesRemaining(int count)
     {
         tilesRemaining = count;
         UpdateUI();
     }
 
-    /// <summary>
-    /// 좌석 라벨(문자열) 설정
-    /// </summary>
     public void SetSeatLabel(PlayerSeat seat, string label)
     {
         seatLabels[seat] = label;
         UpdateUI();
     }
 
-    /// <summary>
-    /// 좌석 점수(int) 설정
-    /// </summary>
     public void SetSeatScore(PlayerSeat seat, int score)
     {
         seatScores[seat] = score;
         UpdateUI();
     }
-
-    private void UpdateUI()
-    {
-        // 국 정보
-        if (textRoundInfo != null)
-            textRoundInfo.text = $"Round: {currentRound}";
-
-        // 남은 패
-        if (textTilesRemaining != null)
-            textTilesRemaining.text = $"Tiles Remaining: {tilesRemaining}";
-
-        // --- 동(E) ---
-        if (textSeatE != null && seatLabels.ContainsKey(PlayerSeat.E))
-            textSeatE.text = seatLabels[PlayerSeat.E];
-        if (textScoreE != null && seatScores.ContainsKey(PlayerSeat.E))
-            textScoreE.text = seatScores[PlayerSeat.E].ToString();
-
-        // --- 남(S) ---
-        if (textSeatS != null && seatLabels.ContainsKey(PlayerSeat.S))
-            textSeatS.text = seatLabels[PlayerSeat.S];
-        if (textScoreS != null && seatScores.ContainsKey(PlayerSeat.S))
-            textScoreS.text = seatScores[PlayerSeat.S].ToString();
-
-        // --- 서(W) ---
-        if (textSeatW != null && seatLabels.ContainsKey(PlayerSeat.W))
-            textSeatW.text = seatLabels[PlayerSeat.W];
-        if (textScoreW != null && seatScores.ContainsKey(PlayerSeat.W))
-            textScoreW.text = seatScores[PlayerSeat.W].ToString();
-
-        // --- 북(N) ---
-        if (textSeatN != null && seatLabels.ContainsKey(PlayerSeat.N))
-            textSeatN.text = seatLabels[PlayerSeat.N];
-        if (textScoreN != null && seatScores.ContainsKey(PlayerSeat.N))
-            textScoreN.text = seatScores[PlayerSeat.N].ToString();
-    }
 }
-

--- a/Assets/Scripts/GamePage/RoundInfoUIManager.cs.meta
+++ b/Assets/Scripts/GamePage/RoundInfoUIManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 80ba28bf3a74440bb912eeb23b0522a4


### PR DESCRIPTION
[![UNITY-18](https://badgen.net/badge/JIRA/UNITY-18/0052CC)](https://mcrs.atlassian.net/browse/UNITY-18) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

<img width="966" alt="스크린샷 2025-03-19 오후 2 19 58" src="https://github.com/user-attachments/assets/daf98f95-0381-4b8d-82b8-bbbcfd7502a8" />
RoundInfoUIManager 를 만들어서 서버에서 데이터를 받았다고 가정하고 표시해주는 부분을 구현했습니다

추후에 database.cs 같은 파일을만들어서
 enum 혹은 Dictionary 를 모아서 파일을 만들어서 정의하는 파일이필요합니다 

[UNITY-18]: https://mcrs.atlassian.net/browse/UNITY-18?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ