### PR TITLE
Unity 28 lobby make name

### DIFF
--- a/Assets/Scenes/LobbyScene.unity
+++ b/Assets/Scenes/LobbyScene.unity
@@ -158,12 +158,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 18649928}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.48228928, y: -0.24451911, z: 5.9739084}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1582585613}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &35462398
 GameObject:
@@ -1063,6 +1063,51 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 591328793}
   m_CullTransparentMesh: 1
+--- !u!1 &647758671
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 647758672}
+  - component: {fileID: 647758673}
+  m_Layer: 0
+  m_Name: LobbyInfoManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &647758672
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 647758671}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -0.48228928, y: 0.24451911, z: -5.9739084}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1582585613}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &647758673
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 647758671}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4d6b1bb8e365f41408ef1ba11af6a187, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nicknameText: {fileID: 1248386179}
 --- !u!1 &675333132
 GameObject:
   m_ObjectHideFlags: 0
@@ -2511,6 +2556,40 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1582585612
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1582585613}
+  m_Layer: 0
+  m_Name: LobbyManagers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1582585613
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1582585612}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.48228928, y: -0.24451911, z: 5.9739084}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 647758672}
+  - {fileID: 1943434485}
+  - {fileID: 18649930}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1625091465
 GameObject:
   m_ObjectHideFlags: 0
@@ -3435,12 +3514,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1943434483}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.48228928, y: -0.24451911, z: 5.9739084}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
-  m_Father: {fileID: 0}
+  m_Father: {fileID: 1582585613}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1966614504
 GameObject:
@@ -3716,5 +3795,4 @@ SceneRoots:
   - {fileID: 932417572}
   - {fileID: 591328797}
   - {fileID: 721565588}
-  - {fileID: 1943434485}
-  - {fileID: 18649930}
+  - {fileID: 1582585613}

--- a/Assets/Scripts/LobbyPage/CoreServerApi.meta
+++ b/Assets/Scripts/LobbyPage/CoreServerApi.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b0f724ea978934e33aebb487d1272d71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/LobbyPage/CoreServerApi/LobbyInfoManager.cs
+++ b/Assets/Scripts/LobbyPage/CoreServerApi/LobbyInfoManager.cs
@@ -1,0 +1,66 @@
+using UnityEngine;
+using UnityEngine.UI;
+using UnityEngine.Networking;
+using System.Collections;
+
+public class LobbyInfoManager : MonoBehaviour
+{
+    [Header("UI References")]
+    [SerializeField] private Text nicknameText; // 닉네임을 표시할 Text
+
+    private string getUserInfoUrl = "http://localhost:8000/api/v1/user/me";
+
+    private void Start()
+    {
+        // 로비씬에 들어오면 유저 정보를 요청
+        StartCoroutine(GetUserInfoFromServer());
+    }
+
+    private IEnumerator GetUserInfoFromServer()
+    {
+        // AccessToken이 저장되어 있어야 함
+        string token = PlayerDataManager.Instance.AccessToken;
+        if (string.IsNullOrEmpty(token))
+        {
+            Debug.LogError("[LobbyInfoManager] 토큰이 없습니다. 로그인이 안 된 상태인가요?");
+            yield break;
+        }
+
+        using (UnityWebRequest www = UnityWebRequest.Get(getUserInfoUrl))
+        {
+            // 인증 헤더 추가
+            www.SetRequestHeader("Authorization", $"Bearer {token}");
+            yield return www.SendWebRequest();
+
+            if (www.result == UnityWebRequest.Result.Success)
+            {
+                Debug.Log("[LobbyInfoManager] 유저 정보 가져오기 성공: " + www.downloadHandler.text);
+
+                // JSON 파싱
+                UserMeResponse userData = JsonUtility.FromJson<UserMeResponse>(www.downloadHandler.text);
+
+                // PlayerDataManager에 저장
+                PlayerDataManager.Instance.SetUserData(userData.uid, userData.nickname, userData.email);
+
+                // UI에 닉네임 표시
+                nicknameText.text = userData.nickname;
+            }
+            else
+            {
+                Debug.LogError("[LobbyInfoManager] 유저 정보 가져오기 실패: " + www.error);
+            }
+        }
+    }
+}
+
+/// <summary>
+/// 서버에서 /api/v1/user/me 응답으로 내려주는 JSON 모델
+/// {"uid":"string","nickname":"string","email":"string"}
+/// </summary>
+[System.Serializable]
+public class UserMeResponse
+{
+    public string uid;
+    public string nickname;
+    public string email;
+}

--- a/Assets/Scripts/LobbyPage/CoreServerApi/LobbyInfoManager.cs.meta
+++ b/Assets/Scripts/LobbyPage/CoreServerApi/LobbyInfoManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4d6b1bb8e365f41408ef1ba11af6a187

--- a/Assets/Scripts/LobbyPage/NicknameCheckManager.cs
+++ b/Assets/Scripts/LobbyPage/NicknameCheckManager.cs
@@ -1,25 +1,29 @@
 using UnityEngine;
 using UnityEngine.UI;
-using UnityEngine.Networking;
-using System.Collections;
+using System.Collections.Generic;
 
 public class NicknameCheckManager : MonoBehaviour
 {
     [Header("UI References")]
-    public InputField nicknameInputField; // 닉네임 입력창
-    public Button nickNameCheckButton;    // "Check" or "Make!" 버튼
+    public InputField nicknameInputField;      // 닉네임 입력창
+    public Button nickNameCheckButton;         // "Check" 버튼
 
-    // 서버 URL (필요 시 실제 도메인/포트로 수정)
-    private string putNicknameUrl = "http://localhost:8000/api/v1/user/me/nickname";
+    // 더미 데이터 (서버 닉네임 목록이라 가정)
+    // 나중엔 서버에 요청해서 같은값이 있는지 확인하는 api 필요
+    private List<string> dummyNicknameList = new List<string>
+    {
+        "www", "aaa", "bbb", "ccc"
+    };
 
     private void Start()
     {
+        // 닉네임 체크 버튼에 리스너 연결
         if (nickNameCheckButton != null)
             nickNameCheckButton.onClick.AddListener(OnClickNicknameCheckButton);
     }
 
     /// <summary>
-    /// "Make!" 버튼(또는 "Check")을 눌렀을 때 호출되는 함수
+    /// "Check" 버튼을 눌렀을 때 호출되는 함수
     /// </summary>
     private void OnClickNicknameCheckButton()
     {
@@ -31,43 +35,17 @@ public class NicknameCheckManager : MonoBehaviour
             return;
         }
 
-        // PUT 요청을 보내 닉네임 업데이트
-        StartCoroutine(PutNicknameToServer(nickname));
-    }
+        // 대소문자 구분 여부를 결정(소문자로 비교 예시)
+        string lowerNick = nickname.ToLower();
 
-    /// <summary>
-    /// 서버에 PUT 요청을 보내 닉네임을 업데이트하는 코루틴
-    /// </summary>
-    private IEnumerator PutNicknameToServer(string newNickname)
-    {
-        // JSON 데이터 생성
-        string jsonBody = $"{{\"nickname\":\"{newNickname}\"}}";
-        byte[] bodyRaw = System.Text.Encoding.UTF8.GetBytes(jsonBody);
-
-        // UnityWebRequest 설정
-        using (UnityWebRequest request = new UnityWebRequest(putNicknameUrl, "PUT"))
+        // 더미 데이터에 이미 있는지 확인
+        if (dummyNicknameList.Contains(lowerNick))
         {
-            request.uploadHandler = new UploadHandlerRaw(bodyRaw);
-            request.downloadHandler = new DownloadHandlerBuffer();
-            request.SetRequestHeader("Content-Type", "application/json");
-
-            // 만약 인증 토큰이 필요하다면 (로그인 시스템과 연동 시)
-            // request.SetRequestHeader("Authorization", "Bearer " + PlayerDataManager.Instance.AccessToken);
-
-            // 요청 전송
-            yield return request.SendWebRequest();
-
-            // 응답 처리
-            if (request.result == UnityWebRequest.Result.Success)
-            {
-                Debug.Log($"[NicknameCheckManager] 닉네임 업데이트 성공: {request.downloadHandler.text}");
-                // 서버가 {"message":"..."} 형태로 응답한다면 파싱 가능
-                // 닉네임 업데이트 후 로컬 변수나 UI 갱신도 가능
-            }
-            else
-            {
-                Debug.LogError($"[NicknameCheckManager] 닉네임 업데이트 실패: {request.error}");
-            }
+            Debug.Log($"중복된 닉네임입니다: {nickname}");
+        }
+        else
+        {
+            Debug.Log($"사용 가능한 닉네임입니다: {nickname}");
         }
     }
 }

--- a/Assets/Scripts/LobbyPage/NicknamePopupManager.cs
+++ b/Assets/Scripts/LobbyPage/NicknamePopupManager.cs
@@ -1,5 +1,7 @@
 using UnityEngine;
 using UnityEngine.UI;
+using UnityEngine.Networking;
+using System.Collections;
 
 public class NicknamePopupManager : MonoBehaviour
 {
@@ -11,47 +13,30 @@ public class NicknamePopupManager : MonoBehaviour
     [Header("테스트 버튼")]
     public Button nicknameButton;          // 기존 UI에 만든 [테스트용] 버튼
 
+    // 서버에 닉네임 업데이트 PUT 요청을 보낼 URL (실제 주소로 변경 필요)
+    private string putNicknameUrl = "http://localhost:8000/api/v1/user/me/nickname";
+
     private void Start()
     {
-        // 씬이 로드되면 기존 닉네임 유무를 확인해 팝업 열지 결정
-        //CheckNicknameOnStart();
-
-        // 테스트용 버튼(닉네임 버튼) 이벤트 연결
+        // 테스트 버튼 클릭 시 팝업을 강제로 열 수 있음
         if (nicknameButton != null)
             nicknameButton.onClick.AddListener(OnClickTestNicknameButton);
 
-        // 팝업 내부 "Make!" 버튼 이벤트 연결
+        // 팝업 내 "Make!" 버튼 클릭 시 PUT 요청을 보내도록 이벤트 연결
         if (nameMakeButton != null)
             nameMakeButton.onClick.AddListener(OnClickNameMakeButton);
     }
 
     /// <summary>
-    /// 씬 로드 시 닉네임이 있는지 확인해서 팝업 표시/비표시
-    /// 
-    /// </summary>
-    ///
-    /*
-    private void CheckNicknameOnStart()
-    {
-    
-    // 닉네임이 없으면 팝업 열기
-    추후에 서버측통신해서 닉네임쿼리를 받아서 처리해야함.
-    // 닉네임이 있으면 팝업 닫기
-    
-    }
-    */
-
-    /// <summary>
-    /// [테스트용] NicknameButton 클릭 시 팝업 열기
+    /// 테스트용 버튼 클릭 시 닉네임 팝업을 표시합니다.
     /// </summary>
     private void OnClickTestNicknameButton()
     {
-        // 이미 닉네임이 있는 경우에도 강제로 팝업을 열어 테스트 가능
         nickNamePopup.SetActive(true);
     }
 
     /// <summary>
-    /// 팝업 내부의 "Make!" 버튼 클릭 시 닉네임 서버 전송 및 팝업 닫기
+    /// 팝업 내 "Make!" 버튼 클릭 시 인풋 필드의 닉네임을 서버에 PUT 요청으로 전송합니다.
     /// </summary>
     private void OnClickNameMakeButton()
     {
@@ -62,16 +47,47 @@ public class NicknamePopupManager : MonoBehaviour
             return;
         }
 
-        // 1) 서버에 닉네임 전송 (예: REST, WebSocket 등)
-        //    ServerManager.Instance.SendNickname(nickname);
-
-        // 2) 로컬에 닉네임 저장 (테스트용)
-        PlayerPrefs.SetString("Nickname", nickname);
-        PlayerPrefs.Save();
-
-        // 3) 팝업 닫기
-        nickNamePopup.SetActive(false);
-
-        Debug.Log($"닉네임 설정 완료: {nickname}");
+        StartCoroutine(UpdateNickname(nickname));
     }
+
+    /// <summary>
+    /// 서버에 PUT 요청을 보내 닉네임을 업데이트합니다.
+    /// 요청 본문은 {"nickname": "입력값"} 형태의 JSON입니다.
+    /// </summary>
+    private IEnumerator UpdateNickname(string nickname)
+    {
+        string jsonBody = $"{{\"nickname\":\"{nickname}\"}}";
+        byte[] bodyRaw = System.Text.Encoding.UTF8.GetBytes(jsonBody);
+
+        using (UnityWebRequest request = new UnityWebRequest(putNicknameUrl, "PUT"))
+        {
+            request.uploadHandler = new UploadHandlerRaw(bodyRaw);
+            request.downloadHandler = new DownloadHandlerBuffer();
+            request.SetRequestHeader("Content-Type", "application/json");
+
+            // Authorization 헤더 추가: PlayerDataManager에 저장된 액세스 토큰 사용
+            request.SetRequestHeader("Authorization", $"Bearer {PlayerDataManager.Instance.AccessToken}");
+
+            yield return request.SendWebRequest();
+
+            if (request.result == UnityWebRequest.Result.Success)
+            {
+                Debug.Log("[NicknamePopupManager] 닉네임 업데이트 성공: " + request.downloadHandler.text);
+
+                // 테스트용: 로컬에 닉네임 저장
+                PlayerPrefs.SetString("Nickname", nickname);
+                PlayerPrefs.Save();
+
+                // 팝업 닫기
+                nickNamePopup.SetActive(false);
+
+                Debug.Log($"닉네임 설정 완료: {nickname}");
+            }
+            else
+            {
+                Debug.LogError("[NicknamePopupManager] 닉네임 업데이트 실패: " + request.error);
+            }
+        }
+    }
+
 }

--- a/Assets/Scripts/LoginPage/PlayerDataManager.cs
+++ b/Assets/Scripts/LoginPage/PlayerDataManager.cs
@@ -8,6 +8,11 @@ public class PlayerDataManager : MonoBehaviour
     public string RefreshToken { get; private set; }
     public bool IsNewUser { get; private set; }
 
+    // 새로 추가: 서버에서 가져온 유저 정보
+    public string Uid { get; private set; }
+    public string Nickname { get; private set; }
+    public string Email { get; private set; }
+
     private void Awake()
     {
         if (Instance == null)
@@ -27,5 +32,16 @@ public class PlayerDataManager : MonoBehaviour
         RefreshToken = refreshToken;
         IsNewUser = isNewUser;
         Debug.Log("[PlayerDataManager] 토큰 저장 완료");
+    }
+
+    /// <summary>
+    /// 서버에서 받아온 유저 정보를 저장
+    /// </summary>
+    public void SetUserData(string uid, string nickname, string email)
+    {
+        Uid = uid;
+        Nickname = nickname;
+        Email = email;
+        Debug.Log($"[PlayerDataManager] 유저 정보 저장: {Nickname}, {Email}");
     }
 }


### PR DESCRIPTION
[![UNITY-28](https://badgen.net/badge/JIRA/UNITY-28/0052CC)](https://mcrs.atlassian.net/browse/UNITY-28) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PlayerDataManager: 로그인 후 저장된 토큰 등 유저 정보를 전역에서 관리합니다.

NicknamePopupManager: 유저가 닉네임이 없을 때 입력한 값을 서버에 PUT 요청하여 업데이트하고, 성공 시 로컬 저장 후 팝업을 닫습니다.

LobbyInfoManager: 로비 씬에 들어오면 GET 요청으로 서버에서 유저 정보를 받아와, UI에 닉네임을 표시합니다.

이 구조로 진행하면,

이미 닉네임이 있다면 로비 씬에서 LobbyInfoManager가 닉네임을 표시하고,

닉네임이 없을 경우 유저가 NicknamePopupManager를 통해 생성하여 서버에 저장한 후,

이후 로비 씬에서 갱신된 닉네임을 표시할 수 있습니다.
현재는 버튼을 눌러 팝업을 띄우고 닉네임을 설정하는 칸을 엽니다
이걸 Manager 를 통해 닉네임칸이 공백이면 닉네임 설정 칸을 열도록 확장할수있습니다.
그리고 현재는 닉네임 중복 체크기능은 있지만 사용하진않습니다.
앞으로 예외처리를 통한 에러팝업도 필요할거같네요


https://github.com/user-attachments/assets/be364429-5654-409e-b3d3-34e5c8b6fed9

[UNITY-28]: https://mcrs.atlassian.net/browse/UNITY-28?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ