### PR TITLE
Unity 40 add furo area

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -1830,6 +1830,37 @@ MonoBehaviour:
     m_VerticalOverflow: 0
     m_LineSpacing: 1
   m_Text: 99
+--- !u!1 &464964138
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 464964139}
+  m_Layer: 0
+  m_Name: FuroPosition_E
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &464964139
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 464964138}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0.7071068, z: 0.7071068, w: 0}
+  m_LocalPosition: {x: 151, y: 0, z: -136}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2107848507}
+  m_LocalEulerAnglesHint: {x: -90, y: 180, z: 0}
 --- !u!1 &465265408
 GameObject:
   m_ObjectHideFlags: 0
@@ -1890,6 +1921,139 @@ MonoBehaviour:
   flowerCountText: {fileID: 1097665546}
   okButton: {fileID: 1762276555}
   testButton: {fileID: 238763015}
+--- !u!1 &474477501
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 474477502}
+  - component: {fileID: 474477505}
+  - component: {fileID: 474477504}
+  - component: {fileID: 474477503}
+  m_Layer: 0
+  m_Name: 'EFuroButton '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &474477502
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 474477501}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 996378643}
+  m_Father: {fileID: 1471120614}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1205, y: 234}
+  m_SizeDelta: {x: 300, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &474477503
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 474477501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 474477504}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 474477501}
+        m_TargetAssemblyTypeName: ReadyButton, Assembly-CSharp
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &474477504
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 474477501}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &474477505
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 474477501}
+  m_CullTransparentMesh: 1
 --- !u!1 &480624412
 GameObject:
   m_ObjectHideFlags: 0
@@ -2913,8 +3077,7 @@ Transform:
   - {fileID: 278709932}
   - {fileID: 1161344455}
   - {fileID: 1016897662}
-  - {fileID: 524205768}
-  - {fileID: 605639310}
+  - {fileID: 1452616776}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &656088377
@@ -4349,6 +4512,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 646768857}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &996378642
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 996378643}
+  - component: {fileID: 996378645}
+  - component: {fileID: 996378644}
+  m_Layer: 0
+  m_Name: GameResultText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &996378643
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996378642}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 474477502}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &996378644
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996378642}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 'EFuroButton '
+--- !u!222 &996378645
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 996378642}
+  m_CullTransparentMesh: 1
 --- !u!1 &1001762061
 GameObject:
   m_ObjectHideFlags: 0
@@ -6252,6 +6494,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1323078176}
   m_CullTransparentMesh: 1
+--- !u!1 &1323599960
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1323599961}
+  m_Layer: 0
+  m_Name: ---UI---FuroArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1323599961
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1323599960}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1327525915
 GameObject:
   m_ObjectHideFlags: 0
@@ -6529,6 +6802,54 @@ Transform:
   - {fileID: 1556015433}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &1423331115
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1423331116}
+  - component: {fileID: 1423331117}
+  m_Layer: 0
+  m_Name: FuroSpawnerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1423331116
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423331115}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1452616776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1423331117
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1423331115}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fce99b11167d947368766933db70b622, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  FuroPosition_E: {fileID: 464964139}
+  FuroPosition_S: {fileID: 2143823887}
+  FuroPosition_W: {fileID: 1555161663}
+  FuroPosition_N: {fileID: 2067121747}
 --- !u!1 &1425491436
 GameObject:
   m_ObjectHideFlags: 0
@@ -6922,6 +7243,39 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1444593825}
   m_CullTransparentMesh: 1
+--- !u!1 &1452616775
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1452616776}
+  m_Layer: 0
+  m_Name: TestButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1452616776
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1452616775}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2108572082}
+  - {fileID: 1423331116}
+  m_Father: {fileID: 646768857}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1471120613
 GameObject:
   m_ObjectHideFlags: 0
@@ -6955,6 +7309,7 @@ Transform:
   - {fileID: 238763014}
   - {fileID: 233802833}
   - {fileID: 1943945384}
+  - {fileID: 474477502}
   m_Father: {fileID: 1668335932}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1512968275
@@ -7231,6 +7586,37 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1554200830}
   m_CullTransparentMesh: 1
+--- !u!1 &1555161662
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1555161663}
+  m_Layer: 0
+  m_Name: FuroPosition_W
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1555161663
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1555161662}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.7071068, y: 0, z: 0, w: 0.7071068}
+  m_LocalPosition: {x: 59, y: 0, z: 65.7}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2107848507}
+  m_LocalEulerAnglesHint: {x: -90, y: 0, z: 0}
 --- !u!1 &1555599383
 GameObject:
   m_ObjectHideFlags: 0
@@ -8697,8 +9083,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 20.2524, y: -464.76}
-  m_SizeDelta: {x: -518.5073, y: -929.51}
+  m_AnchoredPosition: {x: -311.4317, y: -464.76}
+  m_SizeDelta: {x: -1181.8755, y: -929.51}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1806466147
 MonoBehaviour:
@@ -10038,6 +10424,37 @@ RectTransform:
   m_AnchoredPosition: {x: 133.68152, y: 0}
   m_SizeDelta: {x: -555.4369, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2067121746
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2067121747}
+  m_Layer: 0
+  m_Name: FuroPosition_N
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2067121747
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2067121746}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5, y: -0.5, z: -0.5, w: 0.5}
+  m_LocalPosition: {x: -40.1, y: 0, z: 49.6}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2107848507}
+  m_LocalEulerAnglesHint: {x: -90, y: -90, z: 0}
 --- !u!1 &2082270201
 GameObject:
   m_ObjectHideFlags: 0
@@ -10185,6 +10602,87 @@ Transform:
   m_Children: []
   m_Father: {fileID: 42178009}
   m_LocalEulerAnglesHint: {x: -90, y: 90, z: 0}
+--- !u!1 &2107848506
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2107848507}
+  m_Layer: 0
+  m_Name: ---UI---FuroArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2107848507
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2107848506}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -17, y: 15, z: -16}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 464964139}
+  - {fileID: 2143823887}
+  - {fileID: 1555161663}
+  - {fileID: 2067121747}
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2108572081
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2108572082}
+  - component: {fileID: 2108572083}
+  m_Layer: 0
+  m_Name: Furo
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2108572082
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108572081}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1452616776}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2108572083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2108572081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 12d2b9dd89dfa4ad4ae1d8fded526404, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  efuroButton: {fileID: 474477503}
+  furoSpawner: {fileID: 1423331117}
 --- !u!1 &2139926242
 GameObject:
   m_ObjectHideFlags: 0
@@ -10220,6 +10718,37 @@ RectTransform:
   m_AnchoredPosition: {x: -25, y: 0}
   m_SizeDelta: {x: -50, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2143823886
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2143823887}
+  m_Layer: 0
+  m_Name: FuroPosition_S
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2143823887
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2143823886}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0.5, y: 0.5, z: 0.5, w: 0.5}
+  m_LocalPosition: {x: 76.5, y: 0, z: -36.1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2107848507}
+  m_LocalEulerAnglesHint: {x: -90, y: 90, z: 0}
 --- !u!1 &2145694311
 GameObject:
   m_ObjectHideFlags: 0
@@ -10306,8 +10835,10 @@ SceneRoots:
   - {fileID: 1800113854}
   - {fileID: 152682702}
   - {fileID: 798848189}
+  - {fileID: 1323599961}
   - {fileID: 522875599}
   - {fileID: 42178009}
+  - {fileID: 2107848507}
   - {fileID: 1075158129}
   - {fileID: 1401108396}
   - {fileID: 966766195}

--- a/Assets/Scenes/LoginScene.unity
+++ b/Assets/Scenes/LoginScene.unity
@@ -1203,6 +1203,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d4d2b188f50df4b299eb714ef4360ee9, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  canvas: {fileID: 0}
+  bitmapRefreshCycle: 1
+  devicePixelRatio: 1
 --- !u!4 &644508284
 Transform:
   m_ObjectHideFlags: 0
@@ -1624,63 +1627,6 @@ Transform:
   m_Children: []
   m_Father: {fileID: 735380223}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!1001 &1260116941
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 3594.529
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1643.1624
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 634.9381
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071067
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_Name
-      value: 1m3d 1 (1)
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 965418805b439be459a846812c4bb821, type: 3}
 --- !u!1 &1275254961
 GameObject:
   m_ObjectHideFlags: 0
@@ -1943,63 +1889,6 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1958513461}
   m_CullTransparentMesh: 1
---- !u!1001 &2011003594
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 2776.7905
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 1279.127
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 405.61987
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 0.7071067
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: -0.7071068
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: -0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: -8679921383154817045, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 919132149155446097, guid: 965418805b439be459a846812c4bb821, type: 3}
-      propertyPath: m_Name
-      value: 1m3d 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 965418805b439be459a846812c4bb821, type: 3}
 --- !u!1 &2026736743
 GameObject:
   m_ObjectHideFlags: 0
@@ -2134,5 +2023,3 @@ SceneRoots:
   - {fileID: 2026736746}
   - {fileID: 644508284}
   - {fileID: 735380223}
-  - {fileID: 2011003594}
-  - {fileID: 1260116941}

--- a/Assets/Scripts/GamePage/FuroArea.meta
+++ b/Assets/Scripts/GamePage/FuroArea.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 26a7a860bc68b457ea25764c7c03ba2b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/GamePage/FuroArea/EfuroButton.cs
+++ b/Assets/Scripts/GamePage/FuroArea/EfuroButton.cs
@@ -1,0 +1,82 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.Collections.Generic;
+
+namespace MCRGame
+{
+    public class EfuroButton : MonoBehaviour
+    {
+        [SerializeField] private Button efuroButton;    // Efuro 버튼
+        [SerializeField] private FuroSpawner furoSpawner; // FuroSpawner 컴포넌트
+
+        // 더미 데이터 리스트: 각 문자열은 타일 값과 수트를 나타냅니다.
+        private List<string> dummyTileStrings = new List<string>
+        {
+            "234m",
+            "123m",
+            "456m",
+            "789m",
+            "147m"
+        };
+
+        // 현재 더미 데이터 인덱스
+        private int currentIndex = 0;
+
+        private void Start()
+        {
+            if (efuroButton != null)
+            {
+                efuroButton.onClick.AddListener(OnEfuroButtonClicked);
+                Debug.Log("[EfuroButton] Button assigned and onClick listener added.");
+            }
+            else
+            {
+                Debug.LogWarning("[EfuroButton] Efuro button is not assigned!");
+            }
+
+            if (furoSpawner == null)
+            {
+                Debug.LogWarning("[EfuroButton] FuroSpawner is not assigned in Inspector!");
+            }
+        }
+
+        /// <summary>
+        /// Efuro 버튼 클릭 시, 더미 데이터 리스트에서 다음 데이터를 사용해 후로 영역을 생성합니다.
+        /// 리스트의 마지막에 도달하면 인덱스를 0으로 재설정하여 반복합니다.
+        /// </summary>
+        private void OnEfuroButtonClicked()
+        {
+            Debug.Log("[EfuroButton] Efuro button clicked.");
+
+            if (dummyTileStrings.Count == 0)
+            {
+                Debug.LogWarning("[EfuroButton] Dummy data list is empty.");
+                return;
+            }
+
+            Debug.Log("[EfuroButton] Current dummyTileStrings count: " + dummyTileStrings.Count);
+            Debug.Log("[EfuroButton] Current index: " + currentIndex);
+
+            string tileString = dummyTileStrings[currentIndex];
+            Debug.Log("[EfuroButton] Using dummy tile string: " + tileString);
+
+            if (furoSpawner != null)
+            {
+                // 여기서 "chii", seat 0(East)로 호출 (테스트)
+                furoSpawner.SpawnFuro("chii", 0, tileString);
+                Debug.Log("[EfuroButton] SpawnFuro called with parameters: chii, 0, " + tileString);
+            }
+            else
+            {
+                Debug.LogError("[EfuroButton] FuroSpawner is not assigned!");
+            }
+
+            currentIndex++;
+            if (currentIndex >= dummyTileStrings.Count)
+            {
+                currentIndex = 0;
+                Debug.Log("[EfuroButton] Resetting dummy data index to 0.");
+            }
+        }
+    }
+}

--- a/Assets/Scripts/GamePage/FuroArea/EfuroButton.cs.meta
+++ b/Assets/Scripts/GamePage/FuroArea/EfuroButton.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 12d2b9dd89dfa4ad4ae1d8fded526404

--- a/Assets/Scripts/GamePage/FuroArea/FuroSpawner.cs
+++ b/Assets/Scripts/GamePage/FuroArea/FuroSpawner.cs
@@ -1,0 +1,104 @@
+using UnityEngine;
+using System.Collections.Generic;
+
+namespace MCRGame
+{
+    public class FuroSpawner : MonoBehaviour
+    {
+        [Header("Furo Positions (Seat-based)")]
+        [SerializeField] private Transform FuroPosition_E;  // seat=0
+        [SerializeField] private Transform FuroPosition_S;  // seat=1
+        [SerializeField] private Transform FuroPosition_W;  // seat=2
+        [SerializeField] private Transform FuroPosition_N;  // seat=3
+
+        /// <summary>
+        /// 예: furoType="chii", seat=0(East), tileString="234m"
+        /// → FuroPosition_E 아래에 "2m", "3m", "4m" 타일 프리팹을 TileLoader를 통해 가져와 일정 간격으로 배치합니다.
+        /// </summary>
+        public void SpawnFuro(string furoType, int seat, string tileString)
+        {
+            Debug.Log($"[FuroSpawner] SpawnFuro called: furoType={furoType}, seat={seat}, tileString={tileString}");
+
+            // 기준 오브젝트(FuroPosition_E 등)를 기준으로 후로 그룹 생성
+            Transform seatTransform = GetSeatTransform(seat);
+            if (seatTransform == null)
+            {
+                Debug.LogError("[FuroSpawner] Seat transform is null. Check Inspector assignments.");
+                return;
+            }
+            GameObject furoParent = new GameObject($"Furo_{furoType}_{tileString}");
+            furoParent.transform.SetParent(seatTransform, false);
+
+            // "234m" → ["2m", "3m", "4m"]
+            List<string> tileList = ParseTiles(tileString);
+            Debug.Log($"[FuroSpawner] Parsed tiles: {string.Join(", ", tileList)}");
+
+            // 타일 배치: X축 기준 일정 간격 계산
+            float spacing = 15f;  // 간격을 1.5로 늘림
+            float startX = -(tileList.Count - 1) * spacing / 2f;
+
+            foreach (string tile in tileList)
+            {
+                // 예: "2m" → value=2, suit="m"
+                char valueChar = tile[0];
+                int value = valueChar - '0';
+                string suit = tile.Substring(1).ToLower();
+
+                // TileLoader를 통해 3D 프리팹 가져오기
+                GameObject prefab3D = TileLoader.Instance.Get3DPrefab(suit, value);
+                if (prefab3D == null)
+                {
+                    Debug.LogWarning($"[FuroSpawner] Prefab for tile {tile} not found.");
+                    continue;
+                }
+
+                // 프리팹 Instantiate 및 배치
+                GameObject tileObj = Instantiate(prefab3D, furoParent.transform);
+                tileObj.transform.localPosition = new Vector3(startX, 0, 0);
+                // 부모의 회전값을 물려받음 (localRotation을 identity로 설정하면 부모의 회전이 적용됨)
+                tileObj.transform.localRotation = Quaternion.identity;
+                Debug.Log($"[FuroSpawner] Placed tile {tile} at localPosition: {tileObj.transform.localPosition}");
+
+                // 다음 타일 배치를 위해 X 좌표 갱신
+                startX += spacing;
+            }
+        }
+
+        /// <summary>
+        /// 입력 문자열 예: "234m"를 ["2m", "3m", "4m"]로 파싱합니다.
+        /// </summary>
+        private List<string> ParseTiles(string tileString)
+        {
+            if (string.IsNullOrEmpty(tileString) || tileString.Length < 2)
+            {
+                Debug.LogWarning("[FuroSpawner] Invalid tile string.");
+                return new List<string>();
+            }
+
+            char suit = tileString[tileString.Length - 1]; // 예: 'm'
+            string ranks = tileString.Substring(0, tileString.Length - 1); // 예: "234"
+
+            List<string> result = new List<string>();
+            foreach (char c in ranks)
+            {
+                result.Add($"{c}{suit}");
+            }
+            return result;
+        }
+
+        /// <summary>
+        /// seat 번호에 따른 FuroPosition 반환 (0=E, 1=S, 2=W, 3=N)
+        /// </summary>
+        private Transform GetSeatTransform(int seat)
+        {
+            switch (seat)
+            {
+                case 0: return FuroPosition_E;
+                case 1: return FuroPosition_S;
+                case 2: return FuroPosition_W;
+                case 3: return FuroPosition_N;
+                default: return null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/GamePage/FuroArea/FuroSpawner.cs.meta
+++ b/Assets/Scripts/GamePage/FuroArea/FuroSpawner.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: fce99b11167d947368766933db70b622

--- a/Assets/WebGLTemplates/MyTemplate/index.html.meta
+++ b/Assets/WebGLTemplates/MyTemplate/index.html.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6c7523aa0c03541bdbaaa1ddf39e1e1e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[![UNITY-40](https://badgen.net/badge/JIRA/UNITY-40/0052CC)](https://mcrs.atlassian.net/browse/UNITY-40) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

후로영역을 조금 구현했고 지금은 블럭간의 간격조절이 되어있지 않습니다
FuroSpawner 에서 각 후로한 블럭간에 간격조절이 필요하며 치,퐁,캉 일시 해당하는 패를 회전해줘야합니다.
일단은 E 현재보이는 플레이어 기준으로 하나만 버튼을 만들어 테스트했기에 나머지도 구현이 필요합니다
TileLoader 를 사용하고있기때문에 나베가 만든 새로운 버전의 에셋로더로 대체해야합니다.
 EfuroButton 은 더미데이터를 조금 넣어서 테스트 해 볼수있도록 했습니다

[UNITY-40]: https://mcrs.atlassian.net/browse/UNITY-40?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ