### PR TITLE
end TimerUi

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -688,6 +688,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &191371761
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 191371762}
+  - component: {fileID: 191371764}
+  - component: {fileID: 191371763}
+  m_Layer: 0
+  m_Name: PlayerTimerButtonText
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &191371762
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191371761}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1252753517}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &191371763
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191371761}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 14
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 10
+    m_MaxSize: 40
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: PlayerTimerButtonText
+--- !u!222 &191371764
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 191371761}
+  m_CullTransparentMesh: 1
 --- !u!1 &204941199
 GameObject:
   m_ObjectHideFlags: 0
@@ -1970,6 +2049,7 @@ MonoBehaviour:
     sprite: {fileID: 381035312, guid: 241f81c4182b84994be36d1f5bd7afe0, type: 3}
   - actionType: flower
     sprite: {fileID: 3227129927260279833, guid: fcee6971272ce4908a55bf233fc85fea, type: 3}
+  testDummyButton: {fileID: 0}
 --- !u!1 &381490329
 GameObject:
   m_ObjectHideFlags: 0
@@ -3252,6 +3332,7 @@ Transform:
   - {fileID: 524205768}
   - {fileID: 605639310}
   - {fileID: 362724885}
+  - {fileID: 1809140459}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &656088377
@@ -4875,6 +4956,82 @@ Transform:
   - {fileID: 1439177739}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &981310313
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 981310314}
+  - component: {fileID: 981310316}
+  - component: {fileID: 981310315}
+  m_Layer: 5
+  m_Name: Timer
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &981310314
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981310313}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2123852925}
+  m_Father: {fileID: 1668335932}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 730, y: -270}
+  m_SizeDelta: {x: -1820, y: -980}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &981310315
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981310313}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &981310316
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 981310313}
+  m_CullTransparentMesh: 1
 --- !u!1 &994526680
 GameObject:
   m_ObjectHideFlags: 0
@@ -6512,6 +6669,139 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &1252753516
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1252753517}
+  - component: {fileID: 1252753520}
+  - component: {fileID: 1252753519}
+  - component: {fileID: 1252753518}
+  m_Layer: 0
+  m_Name: PlayerTimerButton
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1252753517
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1252753516}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 191371762}
+  m_Father: {fileID: 1471120614}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 1498, y: 616}
+  m_SizeDelta: {x: 300, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1252753518
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1252753516}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 1252753519}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1252753516}
+        m_TargetAssemblyTypeName: ReadyButton, Assembly-CSharp
+        m_MethodName: 
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &1252753519
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1252753516}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1252753520
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1252753516}
+  m_CullTransparentMesh: 1
 --- !u!1 &1254275885
 GameObject:
   m_ObjectHideFlags: 0
@@ -7875,6 +8165,7 @@ Transform:
   - {fileID: 233802833}
   - {fileID: 1943945384}
   - {fileID: 1981325765}
+  - {fileID: 1252753517}
   m_Father: {fileID: 1668335932}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1512968275
@@ -8840,6 +9131,7 @@ RectTransform:
   m_Children:
   - {fileID: 952449370}
   - {fileID: 1806466146}
+  - {fileID: 981310314}
   - {fileID: 1471120614}
   m_Father: {fileID: 798848189}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -9684,6 +9976,52 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1806466145}
   m_CullTransparentMesh: 0
+--- !u!1 &1809140458
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1809140459}
+  - component: {fileID: 1809140460}
+  m_Layer: 0
+  m_Name: PlayerTimerManager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1809140459
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1809140458}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 646768857}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1809140460
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1809140458}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: cacbc9387d3bf4e7c8be33c1384f99e0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  remainingTimeText: {fileID: 0}
+  testRandomTimeButton: {fileID: 0}
 --- !u!1 &1827532292
 GameObject:
   m_ObjectHideFlags: 0
@@ -10747,7 +11085,7 @@ GameObject:
   - component: {fileID: 1981325767}
   - component: {fileID: 1981325766}
   m_Layer: 0
-  m_Name: EtcButtonData
+  m_Name: EtcButtonDataButton
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -11144,7 +11482,7 @@ GameObject:
   - component: {fileID: 2062503915}
   - component: {fileID: 2062503914}
   m_Layer: 0
-  m_Name: EtcButtonData
+  m_Name: EtcButtonDataText
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -11358,6 +11696,85 @@ Transform:
   m_Children: []
   m_Father: {fileID: 42178009}
   m_LocalEulerAnglesHint: {x: -90, y: 90, z: 0}
+--- !u!1 &2123852924
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2123852925}
+  - component: {fileID: 2123852927}
+  - component: {fileID: 2123852926}
+  m_Layer: 5
+  m_Name: 'TimerText '
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2123852925
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123852924}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 981310314}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2123852926
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123852924}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5f7201a12d95ffc409449d95f23cf332, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.19607843, g: 0.19607843, b: 0.19607843, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_FontData:
+    m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+    m_FontSize: 70
+    m_FontStyle: 0
+    m_BestFit: 0
+    m_MinSize: 0
+    m_MaxSize: 100
+    m_Alignment: 4
+    m_AlignByGeometry: 0
+    m_RichText: 1
+    m_HorizontalOverflow: 0
+    m_VerticalOverflow: 0
+    m_LineSpacing: 1
+  m_Text: 20
+--- !u!222 &2123852927
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2123852924}
+  m_CullTransparentMesh: 1
 --- !u!1 &2139926242
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -747,14 +747,14 @@ MonoBehaviour:
       m_Calls: []
   m_FontData:
     m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
-    m_FontSize: 14
+    m_FontSize: 30
     m_FontStyle: 0
     m_BestFit: 0
-    m_MinSize: 10
+    m_MinSize: 3
     m_MaxSize: 40
     m_Alignment: 4
     m_AlignByGeometry: 0
-    m_RichText: 1
+    m_RichText: 0
     m_HorizontalOverflow: 0
     m_VerticalOverflow: 0
     m_LineSpacing: 1
@@ -1996,7 +1996,7 @@ GameObject:
   - component: {fileID: 362724885}
   - component: {fileID: 362724886}
   m_Layer: 0
-  m_Name: ButtonManager
+  m_Name: EtcButtonManager
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -2049,7 +2049,8 @@ MonoBehaviour:
     sprite: {fileID: 381035312, guid: 241f81c4182b84994be36d1f5bd7afe0, type: 3}
   - actionType: flower
     sprite: {fileID: 3227129927260279833, guid: fcee6971272ce4908a55bf233fc85fea, type: 3}
-  testDummyButton: {fileID: 0}
+  testDummyButton: {fileID: 1981325766}
+  playerTimer: {fileID: 1809140460}
 --- !u!1 &381490329
 GameObject:
   m_ObjectHideFlags: 0
@@ -4968,7 +4969,7 @@ GameObject:
   - component: {fileID: 981310316}
   - component: {fileID: 981310315}
   m_Layer: 5
-  m_Name: Timer
+  m_Name: PlayerTimer
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -10020,8 +10021,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: cacbc9387d3bf4e7c8be33c1384f99e0, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  remainingTimeText: {fileID: 0}
-  testRandomTimeButton: {fileID: 0}
+  remainingTimeText: {fileID: 2123852926}
+  testRandomTimeButton: {fileID: 1252753518}
+  buttonManager: {fileID: 362724886}
 --- !u!1 &1827532292
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/UI/GamePage/ButtonManager.cs
+++ b/Assets/Scripts/UI/GamePage/ButtonManager.cs
@@ -29,6 +29,9 @@ namespace MCRGame.UI
         [Header("테스트용 버튼 (더미데이터 호출)")]
         [SerializeField] private Button testDummyButton;
 
+        [Header("통합용 - 남은 시간 관리")]
+        [SerializeField] private PlayerTimer playerTimer;
+
         // 우선순위 사전
         private Dictionary<string, int> priorityDict = new Dictionary<string, int> {
             {"skip", 0},
@@ -123,7 +126,7 @@ namespace MCRGame.UI
                     }
 
                     btn.onClick.RemoveAllListeners();
-                    // 클릭 시 해당 액션을 처리하고 모든 버튼을 비활성화
+                    // 버튼 클릭 시 액션 처리 후, 남은 시간을 전송하고 UI 숨김 처리
                     btn.onClick.AddListener(() => OnActionButtonClicked(action));
                 }
                 else
@@ -141,8 +144,11 @@ namespace MCRGame.UI
         private void OnActionButtonClicked(string action)
         {
             Debug.Log("Action button clicked: " + action);
-            // TODO: 실제 액션 로직 구현
-
+            // 남은 시간을 서버로 전송 (디버그로그로 대체)
+            if (playerTimer != null)
+            {
+                playerTimer.SubmitRemainingTime();
+            }
             // 액션 수행 후 모든 액션 버튼을 비활성화 (숨김)
             HideAllActionButtons();
         }
@@ -177,6 +183,15 @@ namespace MCRGame.UI
             {
                 Debug.LogWarning("dummyJsonList가 비어 있습니다.");
             }
+        }
+
+        /// <summary>
+        /// PlayerTimer에서 시간이 0초가 되었을 때 자동 스킵 처리.
+        /// </summary>
+        public void AutoSkip()
+        {
+            Debug.Log("Auto skip triggered by timeout");
+            OnActionButtonClicked("skip");
         }
     }
 }

--- a/Assets/Scripts/UI/GamePage/PlayerTimer.cs
+++ b/Assets/Scripts/UI/GamePage/PlayerTimer.cs
@@ -1,0 +1,101 @@
+using UnityEngine;
+using UnityEngine.UI;
+using System.Collections;
+
+namespace MCRGame.UI
+{
+    public class PlayerTimer : MonoBehaviour
+    {
+        [Header("UI 연결")]
+        [SerializeField] private Text remainingTimeText;  // 남은 시간 텍스트 (숫자만 표시)
+        [SerializeField] private Button testRandomTimeButton; // 테스트 버튼
+        [SerializeField] private ButtonManager buttonManager; // ButtonManager와 연계
+
+        private int remainingTime;      // 남은 시간 (초 단위)
+        private Coroutine countdownCo;  // 카운트다운 코루틴 추적
+
+        private void Start()
+        {
+            if (testRandomTimeButton != null)
+            {
+                testRandomTimeButton.onClick.AddListener(StartRandomCountdown);
+            }
+        }
+
+        /// <summary>
+        /// 1~60초 사이 랜덤 시간을 설정하고 카운트다운을 시작합니다.
+        /// (실제 환경에서는 서버에서 플레이어의 남은 시간을 받아와야 함)
+        /// </summary>
+        private void StartRandomCountdown()
+        {
+            if (countdownCo != null)
+            {
+                StopCoroutine(countdownCo);
+            }
+            remainingTime = Random.Range(1, 61);
+            // UI가 꺼져있다면 활성화
+            if (remainingTimeText != null)
+            {
+                remainingTimeText.gameObject.SetActive(true);
+            }
+            countdownCo = StartCoroutine(CountdownRoutine());
+        }
+
+        /// <summary>
+        /// 매 초마다 1초씩 줄어드는 카운트다운 코루틴
+        /// </summary>
+        private IEnumerator CountdownRoutine()
+        {
+            while (remainingTime > 0)
+            {
+                UpdateRemainingTimeText();
+                yield return new WaitForSeconds(1f);
+                remainingTime--;
+            }
+            // 마지막 0초 업데이트
+            UpdateRemainingTimeText();
+
+            // 시간이 0초가 되면 타임아웃 처리: 서버 전송(디버그로그) 및 자동 스킵
+            Debug.Log("Timeout, sending server signal: timeout");
+            // UI 숨김 처리
+            if (remainingTimeText != null)
+            {
+                remainingTimeText.gameObject.SetActive(false);
+            }
+            // ButtonManager를 통해 자동 스킵 실행
+            if (buttonManager != null)
+            {
+                buttonManager.AutoSkip();
+            }
+            countdownCo = null;
+        }
+
+        /// <summary>
+        /// 남은 시간을 숫자만 UI Text에 표시합니다.
+        /// </summary>
+        private void UpdateRemainingTimeText()
+        {
+            if (remainingTimeText != null)
+            {
+                remainingTimeText.text = remainingTime.ToString();
+            }
+        }
+
+        /// <summary>
+        /// 버튼매니저의 액션 버튼 클릭 시 호출되어 남은 시간을 서버로 전송(디버그로그로 대체)하고 UI를 숨깁니다.
+        /// </summary>
+        public void SubmitRemainingTime()
+        {
+            Debug.Log("Sending remaining time to server: " + remainingTime);
+            if (remainingTimeText != null)
+            {
+                remainingTimeText.gameObject.SetActive(false);
+            }
+            if (countdownCo != null)
+            {
+                StopCoroutine(countdownCo);
+                countdownCo = null;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/UI/GamePage/PlayerTimer.cs
+++ b/Assets/Scripts/UI/GamePage/PlayerTimer.cs
@@ -11,7 +11,7 @@ namespace MCRGame.UI
         [SerializeField] private Button testRandomTimeButton; // 테스트 버튼
         [SerializeField] private ButtonManager buttonManager; // ButtonManager와 연계
 
-        private int remainingTime;      // 남은 시간 (초 단위)
+        private float remainingTime;      // 남은 시간 (초 단위)
         private Coroutine countdownCo;  // 카운트다운 코루틴 추적
 
         private void Start()
@@ -32,7 +32,8 @@ namespace MCRGame.UI
             {
                 StopCoroutine(countdownCo);
             }
-            remainingTime = Random.Range(1, 61);
+            // float 타입으로 1~60초 사이 랜덤 시간 설정
+            remainingTime = Random.Range(1f, 61f);
             // UI가 꺼져있다면 활성화
             if (remainingTimeText != null)
             {
@@ -41,28 +42,25 @@ namespace MCRGame.UI
             countdownCo = StartCoroutine(CountdownRoutine());
         }
 
+
         /// <summary>
         /// 매 초마다 1초씩 줄어드는 카운트다운 코루틴
         /// </summary>
         private IEnumerator CountdownRoutine()
         {
-            while (remainingTime > 0)
+            while (remainingTime > 0f)
             {
                 UpdateRemainingTimeText();
                 yield return new WaitForSeconds(1f);
-                remainingTime--;
+                remainingTime -= 1f;
             }
             // 마지막 0초 업데이트
             UpdateRemainingTimeText();
-
-            // 시간이 0초가 되면 타임아웃 처리: 서버 전송(디버그로그) 및 자동 스킵
             Debug.Log("Timeout, sending server signal: timeout");
-            // UI 숨김 처리
             if (remainingTimeText != null)
             {
                 remainingTimeText.gameObject.SetActive(false);
             }
-            // ButtonManager를 통해 자동 스킵 실행
             if (buttonManager != null)
             {
                 buttonManager.AutoSkip();
@@ -70,14 +68,15 @@ namespace MCRGame.UI
             countdownCo = null;
         }
 
+
         /// <summary>
-        /// 남은 시간을 숫자만 UI Text에 표시합니다.
+        /// 남은 시간을 정수 형태로 UI Text에 표시합니다.
         /// </summary>
         private void UpdateRemainingTimeText()
         {
             if (remainingTimeText != null)
             {
-                remainingTimeText.text = remainingTime.ToString();
+                remainingTimeText.text = Mathf.CeilToInt(remainingTime).ToString();
             }
         }
 

--- a/Assets/Scripts/UI/GamePage/PlayerTimer.cs.meta
+++ b/Assets/Scripts/UI/GamePage/PlayerTimer.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: cacbc9387d3bf4e7c8be33c1384f99e0

--- a/Assets/WebGLTemplates/MyTemplate/index.html.meta
+++ b/Assets/WebGLTemplates/MyTemplate/index.html.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6c7523aa0c03541bdbaaa1ddf39e1e1e
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
[![UNITY-50](https://badgen.net/badge/JIRA/UNITY-50/0052CC)](https://mcrs.atlassian.net/browse/UNITY-50) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://github.com/user-attachments/assets/dad5a38e-5be6-4112-b810-487034d4a031

PlayerTimer 개선

1~60초 랜덤 시간을 카운트다운하도록 수정

카운트다운이 0초에 도달하면 "timeout" 메시지를 로그에 출력

시간이 0초가 되면 남은 시간 UI를 숨기고, ButtonManager의 AutoSkip() 호출로 자동 스킵 처리

ButtonManager 개선

각 액션 버튼 클릭 시, 남은 시간을 서버에 전송하는(디버그로그) 기능 추가 (SubmitRemainingTime 호출)

AutoSkip() 메서드 추가: 타이머가 0초가 될 경우 스킵 액션을 자동으로 처리하고 버튼들을 비활성화

두 스크립트 연계

PlayerTimer와 ButtonManager 간 연계를 통해, 타이머 타임아웃 시 자동 스킵 및 로그 출력 구현

이로써 플레이어 타이머가 0초에 도달하면 자동으로 "skip" 액션이 실행되어, 남은 시간 전송 및 UI 숨김 처리가 이뤄집니다.

이후에 쯔모에 관한 스크립트가 있다면 플레이어타이머를 적용해줘야합니다
지금은 테스트할때 버튼을      시간테스트 버튼,etc테스트버튼 각 각 눌러줘야합니다
이 기능은 메인플레이어 UI에 들어있습니다

[UNITY-50]: https://mcrs.atlassian.net/browse/UNITY-50?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ