### PR TITLE
UNITY-80/handle websocket message: init haipai, flower, first tsumo

### DIFF
--- a/Assets/Scripts/Networking/GamePage/GameWS.cs
+++ b/Assets/Scripts/Networking/GamePage/GameWS.cs
@@ -5,6 +5,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using UnityEngine;
 using Newtonsoft.Json;
+using MCRGame.UI;
+using System.Collections.Generic;
+using Newtonsoft.Json.Linq;
 
 namespace MCRGame.Net
 {
@@ -113,6 +116,7 @@ namespace MCRGame.Net
                     return;
                 }
                 Debug.Log("[GameWS] Event: " + wsMessage.Event);
+
                 switch (wsMessage.Event)
                 {
                     case GameWSActionType.INIT_EVENT:
@@ -127,6 +131,35 @@ namespace MCRGame.Net
                         break;
                     case GameWSActionType.TSUMO_ACTIONS:
                         Debug.Log("[GameWS] Tsumo actions received.");
+                        break;
+                    case GameWSActionType.GAME_START_INFO:
+                        Debug.Log("[GameWS] GAME_START_INFO event received.");
+                        Debug.Log("[GameWS] Data: " + wsMessage.Data.ToString());
+                        break;
+                    case GameWSActionType.INIT_FLOWER_REPLACEMENT:
+                        Debug.Log("[GameWS] INIT_FLOWER_REPLACEMENT event received.");
+
+                        // new_tiles 파싱
+                        if (wsMessage.Data.TryGetValue("new_tiles", out JToken tilesToken))
+                        {
+                            List<int> newTiles = tilesToken.ToObject<List<int>>();
+                            Debug.Log("[GameWS] New flower replacement tiles: " + string.Join(", ", newTiles));
+                        }
+                        else
+                        {
+                            Debug.LogWarning("[GameWS] INIT_FLOWER_REPLACEMENT: new_tiles 키가 없습니다.");
+                        }
+
+                        // flower_count 파싱
+                        if (wsMessage.Data.TryGetValue("flower_count", out JToken countToken))
+                        {
+                            List<int> flowerCount = countToken.ToObject<List<int>>();
+                            Debug.Log("[GameWS] Flower counts for each hand: " + string.Join(", ", flowerCount));
+                        }
+                        else
+                        {
+                            Debug.LogWarning("[GameWS] INIT_FLOWER_REPLACEMENT: flower_count 키가 없습니다.");
+                        }
                         break;
                     default:
                         Debug.Log("[GameWS] Unhandled event: " + wsMessage.Event);

--- a/Assets/Scripts/Networking/Models/GameWSActionType.cs
+++ b/Assets/Scripts/Networking/Models/GameWSActionType.cs
@@ -7,8 +7,12 @@ namespace MCRGame.Net
     [JsonConverter(typeof(StringEnumConverter))]
     public enum GameWSActionType
     {
+        [EnumMember(Value = "game_start_info")]
+        GAME_START_INFO,
         [EnumMember(Value = "init_event")]
         INIT_EVENT,
+        [EnumMember(Value = "init_flower_replacement")]
+        INIT_FLOWER_REPLACEMENT,
         [EnumMember(Value = "haipai_hand")]
         HAIPAI_HAND,
         [EnumMember(Value = "tsumo_actions")]


### PR DESCRIPTION
[![UNITY-80](https://badgen.net/badge/JIRA/UNITY-80/0052CC)](https://mcrs.atlassian.net/browse/UNITY-80) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

![image](https://github.com/user-attachments/assets/f47b792a-7369-4b80-b501-2b6fe87c734d)

Game start event로 유저마다 할당된 index,

Round init event로 배패와 자리,

init flower replacement로 flower tile을 빼고 어떤 tile들을 쯔모했는지, 그리고 4명이 각각 flower tile을 몇 개 뺐는지를

웹소켓으로 받도록 하였습니다

첫 쯔모까지 연동하였습니다. 화면에 받은 event에 맞게 반영하는 UI조정 하면 될것같습니다.

그리고 init flower replacement에서 flower tile을 어떤 순서대로 뺐는지(flower tile을 패산에서 가져와서 또 뺐으면 화면에 보여주는 연출에 따라 어떤 flower tile을 가져왔는지가 필요할수도 있으니)도 주면 좋을것 같습니다.

[UNITY-80]: https://mcrs.atlassian.net/browse/UNITY-80?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ