### PR TITLE
UNITY-92-discard-with-websocket

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -3476,6 +3476,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameHandManager: {fileID: 866534060}
+  discardManager: {fileID: 1753036464}
   leftTilesText: {fileID: 84894197}
   currentRoundText: {fileID: 2007157733}
   playersHand3DFields:
@@ -3537,6 +3538,7 @@ MonoBehaviour:
   huButtonSprite: {fileID: -6029327314112583697, guid: 3684b43708472426488051f0e9d114c5, type: 3}
   flowerButtonSprite: {fileID: 3227129927260279833, guid: 215e0120c1bce4f9d8f00dacce484176, type: 3}
   timerText: {fileID: 2123852926}
+  IsMyTurn: 0
 --- !u!4 &1254287264
 Transform:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Game/GameMessageMediator.cs
+++ b/Assets/Scripts/Game/GameMessageMediator.cs
@@ -126,9 +126,16 @@ namespace MCRGame.Game
                 case GameWSActionType.TSUMO_ACTIONS:
                     Debug.Log("[GameMessageMediator] Tsumo actions received.");
                     // message.Data는 JObject이므로 바로 넘겨줌
-                    GameManager.Instance.ProcessTsumoActions((JObject)message.Data);
+                    GameManager.Instance.ProcessTsumoActions(message.Data);
                     break;
-
+                case GameWSActionType.DISCARD_ACTIONS:
+                    Debug.Log("[GameMessageMediator] Discard actions received.");
+                    GameManager.Instance.ProcessDiscardActions(message.Data);
+                    break;
+                case GameWSActionType.DISCARD:
+                    Debug.Log("[GameMessageMediator] Discard Confirmed.");
+                    GameManager.Instance.ConfirmDiscard(message.Data);
+                    break;
                 case GameWSActionType.INIT_FLOWER_REPLACEMENT:
                     Debug.Log("[GameMessageMediator] INIT_FLOWER_REPLACEMENT event received.");
 

--- a/Assets/Scripts/UI/GamePage/DiscardManager.cs
+++ b/Assets/Scripts/UI/GamePage/DiscardManager.cs
@@ -28,10 +28,25 @@ namespace MCRGame.UI
 
         void Awake()
         {
-            kawas[RelativeSeat.SELF]  = new List<GameObject>();
+            kawas[RelativeSeat.SELF] = new List<GameObject>();
             kawas[RelativeSeat.SHIMO] = new List<GameObject>();
-            kawas[RelativeSeat.TOI]   = new List<GameObject>();
-            kawas[RelativeSeat.KAMI]  = new List<GameObject>();
+            kawas[RelativeSeat.TOI] = new List<GameObject>();
+            kawas[RelativeSeat.KAMI] = new List<GameObject>();
+        }
+
+        public void InitRound()
+        {
+            foreach (var kvp in kawas)
+            {
+                List<GameObject> list = kvp.Value;
+                foreach (var go in list)
+                {
+                    if (go != null)
+                        Destroy(go);
+                }
+                list.Clear();
+            }
+            tileObjectDictionary.Clear();
         }
 
         public void DiscardTile(RelativeSeat seat, GameTile tile)
@@ -39,11 +54,11 @@ namespace MCRGame.UI
             Transform origin = GetDiscardPosition(seat);
 
             int index = kawas[seat].Count;
-            int row   = index / maxTilesPerRow;
-            int col   = index % maxTilesPerRow;
+            int row = index / maxTilesPerRow;
+            int col = index % maxTilesPerRow;
 
             // 최종 위치 오프셋
-            Vector3 offset   = ComputeOffset(seat, col, row);
+            Vector3 offset = ComputeOffset(seat, col, row);
             Vector3 finalPos = origin.position + offset;
             Quaternion finalRot = origin.rotation;
 
@@ -76,11 +91,11 @@ namespace MCRGame.UI
         {
             return seat switch
             {
-                RelativeSeat.SELF  => Vector3.right  * (col * tileSpacing) + Vector3.back    * (row * rowSpacing),
-                RelativeSeat.SHIMO => Vector3.forward * (col * tileSpacing) + Vector3.right   * (row * rowSpacing),
-                RelativeSeat.TOI   => Vector3.left   * (col * tileSpacing) + Vector3.forward * (row * rowSpacing),
-                RelativeSeat.KAMI  => Vector3.left   * (row * rowSpacing) + Vector3.back    * (col * tileSpacing),
-                _                  => Vector3.zero,
+                RelativeSeat.SELF => Vector3.right * (col * tileSpacing) + Vector3.back * (row * rowSpacing),
+                RelativeSeat.SHIMO => Vector3.forward * (col * tileSpacing) + Vector3.right * (row * rowSpacing),
+                RelativeSeat.TOI => Vector3.left * (col * tileSpacing) + Vector3.forward * (row * rowSpacing),
+                RelativeSeat.KAMI => Vector3.left * (row * rowSpacing) + Vector3.back * (col * tileSpacing),
+                _ => Vector3.zero,
             };
         }
 
@@ -97,10 +112,10 @@ namespace MCRGame.UI
             Vector3 dirCol, dirRow;
             switch (seat)
             {
-                case RelativeSeat.SELF:  dirCol = Vector3.right;  dirRow = Vector3.back;    break;
-                case RelativeSeat.SHIMO: dirCol = Vector3.forward; dirRow = Vector3.right;   break;
-                case RelativeSeat.TOI:   dirCol = Vector3.left;   dirRow = Vector3.forward; break;
-                default:                  dirCol = Vector3.back;   dirRow = Vector3.left;    break;
+                case RelativeSeat.SELF: dirCol = Vector3.right; dirRow = Vector3.back; break;
+                case RelativeSeat.SHIMO: dirCol = Vector3.forward; dirRow = Vector3.right; break;
+                case RelativeSeat.TOI: dirCol = Vector3.left; dirRow = Vector3.forward; break;
+                default: dirCol = Vector3.back; dirRow = Vector3.left; break;
             }
             Vector3 startOffset = dirCol * (col * tileSpacing)
                                 + dirRow * ((row + extraRowOffset) * rowSpacing);
@@ -124,14 +139,14 @@ namespace MCRGame.UI
             }
 
             // 3) 낙하 + 페이드인
-            float elapsed   = 0f;
+            float elapsed = 0f;
             float totalTime = dropDuration;
             float y0 = startPos.y;
             float y1 = finalPos.y;
-            float a  = 2f * (y1 - y0) / (totalTime * totalTime);
+            float a = 2f * (y1 - y0) / (totalTime * totalTime);
 
             Vector3 horizStart = new Vector3(startPos.x, 0f, startPos.z);
-            Vector3 horizEnd   = new Vector3(finalPos.x, 0f, finalPos.z);
+            Vector3 horizEnd = new Vector3(finalPos.x, 0f, finalPos.z);
 
             while (elapsed < totalTime)
             {
@@ -203,11 +218,11 @@ namespace MCRGame.UI
 
         private Transform GetDiscardPosition(RelativeSeat seat) => seat switch
         {
-            RelativeSeat.SELF  => discardPosSELF,
+            RelativeSeat.SELF => discardPosSELF,
             RelativeSeat.SHIMO => discardPosSHIMO,
-            RelativeSeat.TOI   => discardPosTOI,
-            RelativeSeat.KAMI  => discardPosKAMI,
-            _                  => null,
+            RelativeSeat.TOI => discardPosTOI,
+            RelativeSeat.KAMI => discardPosKAMI,
+            _ => null,
         };
     }
 }


### PR DESCRIPTION
[![UNITY-92](https://badgen.net/badge/JIRA/UNITY-92/0052CC)](https://mcrs.atlassian.net/browse/UNITY-92) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://github.com/user-attachments/assets/88554925-1cb4-4e15-8a71-e4024c628a2e


타패 웹소켓 통신 구현했습니다

타가의 쯔모시 타가 손패 영역에 쯔모패 넣는거 추가 구현 해야합니다

[UNITY-92]: https://mcrs.atlassian.net/browse/UNITY-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ