### PR TITLE
 UNITY-93-add-websocket-action-handler

### DIFF
--- a/Assets/Scripts/Common/Game.cs
+++ b/Assets/Scripts/Common/Game.cs
@@ -23,7 +23,7 @@ namespace MCRGame.Common
         [JsonProperty("type")]
         public GameActionType Type { get; set; }
 
-        [JsonProperty("seatPriority")]
+        [JsonProperty("seat_priority")]
         public RelativeSeat SeatPriority { get; set; }
 
         [JsonProperty("tile")]

--- a/Assets/Scripts/Common/Types.cs
+++ b/Assets/Scripts/Common/Types.cs
@@ -14,7 +14,8 @@ namespace MCRGame.Common
         INIT_FLOWER = 9,
         HU = 10,
         ROBBING_KONG = 11,
-        INIT_FLOWER_OK = 12
+        INIT_FLOWER_OK = 12,
+        SKIP = 13,
     }
 
     public static class GameEventTypeExtensions

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -198,11 +198,6 @@ namespace MCRGame.Game
             // 2) action_id, 남은 시간 초기화
             currentActionId = data["action_id"].ToObject<int>();
             remainingTime = data["left_time"].ToObject<float>();
-            GameTile newTsumoTile = (GameTile)data["tile"].ToObject<int>();
-            if (gameHandManager.GameHand.HandSize < GameHand.FULL_HAND_SIZE)
-            {
-                StartCoroutine(gameHandManager.AddTsumo(newTsumoTile));
-            }
 
             // 3) JSON.NET으로 GameAction 리스트로 바로 변환
             var list = data["actions"].ToObject<List<GameAction>>();
@@ -289,13 +284,28 @@ namespace MCRGame.Game
         {
             Debug.Log($"액션 선택: {action.Type} / 타일: {action.Tile}");
             // TODO: 선택된 action_id와 action.Type, action.Tile 서버 전송
+            _ = SendSelectedAction(action: action);
             ClearActionUI();
+        }
+
+        private async Task SendSelectedAction(GameAction action)
+        {
+            var payload = new {
+                action_type = action.Type,
+                action_tile = action.Tile,
+                action_id = currentActionId,
+            };
+            await GameWS.Instance.SendGameEventAsync(action:GameWSActionType.RETURN_ACTION, payload: payload);
         }
 
         private void OnSkipButtonClicked()
         {
             Debug.Log("Skip 선택");
-            // TODO: Skip 서버 전송
+            GameAction SkipAction = new GameAction();
+            SkipAction.Type = GameActionType.SKIP;
+            SkipAction.Tile = GameTile.M1;
+            SkipAction.SeatPriority = RelativeSeat.SELF;
+            _ = SendSelectedAction(action: SkipAction);
             ClearActionUI();
         }
 

--- a/Assets/Scripts/Networking/GamePage/GameWS.cs
+++ b/Assets/Scripts/Networking/GamePage/GameWS.cs
@@ -156,8 +156,8 @@ namespace MCRGame.Net
             // 예: { "event": "game_event", "data": { "event_type": 12, "action_id": 0, "data": { ... } } }
             var messageObj = new
             {
-                @event = action == GameWSActionType.GAME_EVENT ? "game_event" : action.ToString().ToLowerInvariant(),
-                data = payload
+                @event = action,
+                data = payload,
             };
 
             string jsonMessage = JsonConvert.SerializeObject(messageObj);

--- a/Assets/Scripts/Networking/Models/GameWSActionType.cs
+++ b/Assets/Scripts/Networking/Models/GameWSActionType.cs
@@ -10,7 +10,8 @@ namespace MCRGame.Net
         
         [EnumMember(Value = "game_event")]
         GAME_EVENT,
-        
+        [EnumMember(Value = "return_action")]
+        RETURN_ACTION,
         [EnumMember(Value = "game_start_info")]
         GAME_START_INFO,
         [EnumMember(Value = "init_event")]


### PR DESCRIPTION
[![UNITY-93](https://badgen.net/badge/JIRA/UNITY-93/0052CC)](https://mcrs.atlassian.net/browse/UNITY-93) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://github.com/user-attachments/assets/7e2dc0ca-8282-4197-b0b9-42b167a3aeeb

쯔모, 타패에 따른 액션 송수신을 웹소켓을 통해 구현하였습니다.

아직 스킵 말고는 클라이언트 측에 반영되는 액션은 없습니다. 구현해야 합니다.

타가 쯔모시 전파하여 쯔모한 타가의 손패에 쯔모패 추가하는 것 또한 구현해야합니다.

[UNITY-93]: https://mcrs.atlassian.net/browse/UNITY-93?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ