### PR TITLE
UNITY-129-add-score-diff-display

### DIFF
--- a/Assets/Scenes/GameScene.unity
+++ b/Assets/Scenes/GameScene.unity
@@ -3293,6 +3293,101 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &710386008
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 710386009}
+  - component: {fileID: 710386011}
+  - component: {fileID: 710386010}
+  - component: {fileID: 710386012}
+  m_Layer: 0
+  m_Name: CenterScoreHoverArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &710386009
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710386008}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 0.25, y: 0.25, z: 0.25}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 866773031}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &710386010
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710386008}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.101960786, g: 0.101960786, b: 0.11372549, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &710386011
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710386008}
+  m_CullTransparentMesh: 1
+--- !u!114 &710386012
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 710386008}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 17ff59088f8686a4188a07a4ad6956c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scoreText_Self: {fileID: 999382808}
+  scoreText_Shimo: {fileID: 763404407}
+  scoreText_Toi: {fileID: 545457059}
+  scoreText_Kami: {fileID: 716526408}
+  positiveColor: {r: 0.13725491, g: 0.9019608, b: 0.64705884, a: 1}
+  zeroColor: {r: 0.7529412, g: 0.7529412, b: 0.7529412, a: 1}
+  negativeColor: {r: 1, g: 0.41568628, b: 0.41568628, a: 1}
 --- !u!1 &716526404
 GameObject:
   m_ObjectHideFlags: 0
@@ -3973,6 +4068,7 @@ RectTransform:
   - {fileID: 212856254}
   - {fileID: 1002312786}
   - {fileID: 1668431598}
+  - {fileID: 710386009}
   m_Father: {fileID: 1581055772}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}

--- a/Assets/Scripts/Game/CenterHoverDisplay.cs
+++ b/Assets/Scripts/Game/CenterHoverDisplay.cs
@@ -1,0 +1,131 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.EventSystems;
+using TMPro;
+using MCRGame.UI;
+using MCRGame.Common;
+using MCRGame.Net;
+
+namespace MCRGame.Game
+{
+    public class CenterScoreHoverDisplay :
+        MonoBehaviour,
+        IPointerEnterHandler,
+        IPointerExitHandler,
+        IPointerClickHandler          // ← 추가
+    {
+        [Header("Score Texts (RelativeSeat 순서)")]
+        [SerializeField] private TextMeshProUGUI scoreText_Self;
+        [SerializeField] private TextMeshProUGUI scoreText_Shimo;
+        [SerializeField] private TextMeshProUGUI scoreText_Toi;
+        [SerializeField] private TextMeshProUGUI scoreText_Kami;
+
+        [Header("Colors")]
+        [SerializeField] private Color positiveColor = new (0x23/255f, 0xE6/255f, 0xA5/255f); // #23E6A5
+        [SerializeField] private Color zeroColor     = new (0xC0/255f, 0xC0/255f, 0xC0/255f); // #C0C0C0
+        [SerializeField] private Color negativeColor = new (0xFF/255f, 0x6A/255f, 0x6A/255f); // #FF6A6A
+
+        private Dictionary<RelativeSeat, TextMeshProUGUI> seatToText;
+        private bool hovering;
+        private Coroutine holdRoutine;         // 클릭 홀드용
+        private const float HOLD_SECONDS = 1f; // diff 유지 시간
+
+        private void Awake()
+        {
+            seatToText = new()
+            {
+                { RelativeSeat.SELF,  scoreText_Self  },
+                { RelativeSeat.SHIMO, scoreText_Shimo },
+                { RelativeSeat.TOI,   scoreText_Toi   },
+                { RelativeSeat.KAMI,  scoreText_Kami  },
+            };
+        }
+
+        /* ───────────────── Pointer ───────────────── */
+
+        public void OnPointerEnter(PointerEventData eventData)
+        {
+            hovering = true;
+            ShowDifference();
+        }
+
+        public void OnPointerExit(PointerEventData eventData)
+        {
+            hovering = false;
+            // 클릭 홀드 중이 아니면 즉시 복구
+            if (holdRoutine == null && GameManager.Instance != null)
+                GameManager.Instance.UpdateScoreText();
+        }
+
+        public void OnPointerClick(PointerEventData eventData)
+        {
+            // 좌클릭만 처리
+            if (eventData.button != PointerEventData.InputButton.Left) return;
+
+            ShowDifference();               // 클릭 시 한 번 더 갱신
+            // 기존 코루틴이 돌고 있으면 초기화
+            if (holdRoutine != null) StopCoroutine(holdRoutine);
+            holdRoutine = StartCoroutine(HoldDiffThenRestore());
+        }
+
+        /* ─────────── Diff 표시 & 복구 ─────────── */
+
+        private IEnumerator HoldDiffThenRestore()
+        {
+            yield return new WaitForSeconds(HOLD_SECONDS);
+            holdRoutine = null;              // 코루틴 끝남 표식
+            // 여전히 마우스가 올려져 있으면 diff 그대로 두고,
+            // 빠져 있다면 원상 복구
+            if (!hovering && GameManager.Instance != null)
+                GameManager.Instance.UpdateScoreText();
+        }
+
+        private void ShowDifference()
+        {
+            var gm = GameManager.Instance;
+            if (gm == null || gm.Players == null) return;
+
+            int selfScore = 0;
+            var me = gm.Players.Find(p => p.Uid == PlayerDataManager.Instance.Uid);
+            if (me != null) selfScore = me.Score;
+
+            foreach (var (rel, txt) in seatToText)
+            {
+                if (txt == null) continue;
+
+                AbsoluteSeat abs = rel.ToAbsoluteSeat(gm.MySeat);
+                if (!gm.seatToPlayerIndex.TryGetValue(abs, out int idx) ||
+                    idx < 0 || idx >= gm.Players.Count)
+                {
+                    txt.text = "--";
+                    txt.color = zeroColor;
+                    continue;
+                }
+
+                var player = gm.Players[idx];
+                int diff = (rel == RelativeSeat.SELF) ? 0 : player.Score - selfScore;
+                ApplyStyle(txt, diff);
+            }
+        }
+
+        private void ApplyStyle(TextMeshProUGUI txt, int value)
+        {
+            if (value > 0)
+            {
+                txt.text  = "+" + value;
+                txt.color = positiveColor;
+            }
+            else if (value < 0)
+            {
+                txt.text  = value.ToString();
+                txt.color = negativeColor;
+            }
+            else
+            {
+                txt.text  = "+0";
+                txt.color = zeroColor;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Game/CenterHoverDisplay.cs.meta
+++ b/Assets/Scripts/Game/CenterHoverDisplay.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 17ff59088f8686a4188a07a4ad6956c3

--- a/Assets/Scripts/Game/GameManager.cs
+++ b/Assets/Scripts/Game/GameManager.cs
@@ -70,11 +70,11 @@ namespace MCRGame.Game
 
         [Header("Score Colors")]
         [Tooltip("양의 점수일 때 텍스트 색상")]
-        [SerializeField] private Color positiveScoreColor = new Color(0f, 0.0941f, 0.7373f); // #0018CB
+        [SerializeField] private Color positiveScoreColor = new Color(0x5F / 255f, 0xD8 / 255f, 0xA2 / 255f); // #5FD8A2
         [Tooltip("0점일 때 텍스트 색상")]
-        [SerializeField] private Color zeroScoreColor = Color.white;                  // #FFFFFF
+        [SerializeField] private Color zeroScoreColor = new Color(0xB0 / 255f, 0xB0 / 255f, 0xB0 / 255f); // #B0B0B0
         [Tooltip("음의 점수일 때 텍스트 색상")]
-        [SerializeField] private Color negativeScoreColor = new Color(0.7804f, 0.7569f, 0.3186f); // #C7C151
+        [SerializeField] private Color negativeScoreColor = new Color(0xE2 / 255f, 0x78 / 255f, 0x78 / 255f); // #E27878
 
         public Color PositiveScoreColor => positiveScoreColor;
         public Color ZeroScoreColor => zeroScoreColor;

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -35,24 +35,24 @@ MonoBehaviour:
       m_List:
       - rid: 7752762179098771456
       - rid: 7752762179098771457
-      - rid: 3994546178460484052
+      - rid: 3994546189827047555
       - rid: 7752762179098771459
-      - rid: 3994546178460484053
+      - rid: 3994546189827047556
       - rid: 7752762179098771461
       - rid: 7752762179098771462
-      - rid: 3994546178460484054
+      - rid: 3994546189827047557
       - rid: 7752762179098771464
-      - rid: 3994546178460484055
+      - rid: 3994546189827047558
       - rid: 7752762179098771466
-      - rid: 3994546178460484056
+      - rid: 3994546189827047559
       - rid: 7752762179098771468
-      - rid: 3994546178460484057
-      - rid: 3994546178460484058
-      - rid: 3994546178460484059
+      - rid: 3994546189827047560
+      - rid: 3994546189827047561
+      - rid: 3994546189827047562
       - rid: 7752762179098771472
-      - rid: 3994546178460484060
-      - rid: 3994546178460484061
-      - rid: 3994546178460484062
+      - rid: 3994546189827047563
+      - rid: 3994546189827047564
+      - rid: 3994546189827047565
       - rid: 7752762179098771476
     m_RuntimeSettings:
       m_List:
@@ -89,7 +89,7 @@ MonoBehaviour:
   references:
     version: 2
     RefIds:
-    - rid: 3994546178460484052
+    - rid: 3994546189827047555
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -101,14 +101,14 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 3994546178460484053
+    - rid: 3994546189827047556
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 0
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 3994546178460484054
+    - rid: 3994546189827047557
       type: {class: UniversalRendererResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -116,7 +116,7 @@ MonoBehaviour:
         m_CameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf, type: 3}
         m_StencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
         m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
-    - rid: 3994546178460484055
+    - rid: 3994546189827047558
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -125,7 +125,7 @@ MonoBehaviour:
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
         m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-    - rid: 3994546178460484056
+    - rid: 3994546189827047559
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -138,21 +138,21 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 3994546178460484057
+    - rid: 3994546189827047560
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
         probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
         probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
-    - rid: 3994546178460484058
+    - rid: 3994546189827047561
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 3994546178460484059
+    - rid: 3994546189827047562
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -165,7 +165,7 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 3994546178460484060
+    - rid: 3994546189827047563
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -175,13 +175,13 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 3994546178460484061
+    - rid: 3994546189827047564
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 3994546178460484062
+    - rid: 3994546189827047565
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1


### PR DESCRIPTION
[![UNITY-129](https://badgen.net/badge/JIRA/UNITY-129/0052CC)](https://mcrs.atlassian.net/browse/UNITY-129) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

https://github.com/user-attachments/assets/945f8b36-3bee-449d-93f1-e71075db802f

점수 화면 위에 마우스가 있는 동안, 그리고 클릭하면 그 후 1초동안 점수 차이를 표기하는 기능을 추가했습니다.

[UNITY-129]: https://mcrs.atlassian.net/browse/UNITY-129?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ