### PR TITLE
UNITY-158 fix timeout double discard bug

### DIFF
--- a/Assets/Scripts/Game/GameManager/GameManager.Network.cs
+++ b/Assets/Scripts/Game/GameManager/GameManager.Network.cs
@@ -81,7 +81,12 @@ namespace MCRGame.Game
             var payload = new
             {
                 event_type = (int)GameEventType.DISCARD,
-                data = new { tile = (int)tile, is_tsumogiri }
+                action_id = currentActionId,
+                data = new
+                {
+                    tile = (int)tile,
+                    is_tsumogiri,
+                }
             };
             GameWS.Instance.SendGameEvent(GameWSActionType.GAME_EVENT, payload);
         }

--- a/Assets/UniversalRenderPipelineGlobalSettings.asset
+++ b/Assets/UniversalRenderPipelineGlobalSettings.asset
@@ -35,24 +35,24 @@ MonoBehaviour:
       m_List:
       - rid: 7752762179098771456
       - rid: 1932564374502768879
-      - rid: 1932564762852327509
+      - rid: 1932564762852327521
       - rid: 7752762179098771459
-      - rid: 1932564762852327510
+      - rid: 1932564762852327522
       - rid: 7752762179098771461
       - rid: 7752762179098771462
-      - rid: 1932564762852327511
+      - rid: 1932564762852327523
       - rid: 7752762179098771464
-      - rid: 1932564762852327512
+      - rid: 1932564762852327524
       - rid: 7752762179098771466
-      - rid: 1932564762852327513
+      - rid: 1932564762852327525
       - rid: 7752762179098771468
-      - rid: 1932564762852327514
-      - rid: 1932564762852327515
-      - rid: 1932564762852327516
+      - rid: 1932564762852327526
+      - rid: 1932564762852327527
+      - rid: 1932564762852327528
       - rid: 7752762179098771472
-      - rid: 1932564762852327517
-      - rid: 1932564762852327518
-      - rid: 1932564762852327519
+      - rid: 1932564762852327529
+      - rid: 1932564762852327530
+      - rid: 1932564762852327531
       - rid: 7752762179098771476
     m_RuntimeSettings:
       m_List:
@@ -104,7 +104,7 @@ MonoBehaviour:
         m_DefaultLitMaterial: {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
         m_DefaultUnlitMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
         m_DefaultMaskMaterial: {fileID: 2100000, guid: 15d0c3709176029428a0da2f8cecf0b5, type: 2}
-    - rid: 1932564762852327509
+    - rid: 1932564762852327521
       type: {class: UniversalRenderPipelineEditorShaders, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_AutodeskInteractive: {fileID: 4800000, guid: 0e9d5a909a1f7e84882a534d0d11e49f, type: 3}
@@ -116,14 +116,14 @@ MonoBehaviour:
         m_DefaultSpeedTree7Shader: {fileID: 4800000, guid: 0f4122b9a743b744abe2fb6a0a88868b, type: 3}
         m_DefaultSpeedTree8Shader: {fileID: -6465566751694194690, guid: 9920c1f1781549a46ba081a2a15a16ec, type: 3}
         m_DefaultSpeedTree9Shader: {fileID: -6465566751694194690, guid: cbd3e1cc4ae141c42a30e33b4d666a61, type: 3}
-    - rid: 1932564762852327510
+    - rid: 1932564762852327522
       type: {class: URPShaderStrippingSetting, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
         m_StripUnusedPostProcessingVariants: 0
         m_StripUnusedVariants: 1
         m_StripScreenCoordOverrideVariants: 1
-    - rid: 1932564762852327511
+    - rid: 1932564762852327523
       type: {class: UniversalRendererResources, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_Version: 0
@@ -131,7 +131,7 @@ MonoBehaviour:
         m_CameraMotionVector: {fileID: 4800000, guid: c56b7e0d4c7cb484e959caeeedae9bbf, type: 3}
         m_StencilDeferredPS: {fileID: 4800000, guid: e9155b26e1bc55942a41e518703fe304, type: 3}
         m_DBufferClear: {fileID: 4800000, guid: f056d8bd2a1c7e44e9729144b4c70395, type: 3}
-    - rid: 1932564762852327512
+    - rid: 1932564762852327524
       type: {class: UniversalRenderPipelineEditorMaterials, ns: UnityEngine.Rendering.Universal, asm: Unity.RenderPipelines.Universal.Runtime}
       data:
         m_DefaultMaterial: {fileID: 2100000, guid: 31321ba15b8f8eb4c954353edc038b1d, type: 2}
@@ -140,7 +140,7 @@ MonoBehaviour:
         m_DefaultTerrainMaterial: {fileID: 2100000, guid: 594ea882c5a793440b60ff72d896021e, type: 2}
         m_DefaultDecalMaterial: {fileID: 2100000, guid: 31d0dcc6f2dd4e4408d18036a2c93862, type: 2}
         m_DefaultSpriteMaterial: {fileID: 2100000, guid: 9dfc825aed78fcd4ba02077103263b40, type: 2}
-    - rid: 1932564762852327513
+    - rid: 1932564762852327525
       type: {class: GPUResidentDrawerResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.GPUDriven.Runtime}
       data:
         m_Version: 0
@@ -153,21 +153,21 @@ MonoBehaviour:
         m_OcclusionCullingDebugKernels: {fileID: 7200000, guid: b23e766bcf50ca4438ef186b174557df, type: 3}
         m_DebugOcclusionTestPS: {fileID: 4800000, guid: d3f0849180c2d0944bc71060693df100, type: 3}
         m_DebugOccluderPS: {fileID: 4800000, guid: b3c92426a88625841ab15ca6a7917248, type: 3}
-    - rid: 1932564762852327514
+    - rid: 1932564762852327526
       type: {class: ProbeVolumeRuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
         probeVolumeBlendStatesCS: {fileID: 7200000, guid: a3f7b8c99de28a94684cb1daebeccf5d, type: 3}
         probeVolumeUploadDataCS: {fileID: 7200000, guid: 0951de5992461754fa73650732c4954c, type: 3}
         probeVolumeUploadDataL2CS: {fileID: 7200000, guid: 6196f34ed825db14b81fb3eb0ea8d931, type: 3}
-    - rid: 1932564762852327515
+    - rid: 1932564762852327527
       type: {class: IncludeAdditionalRPAssets, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_version: 0
         m_IncludeReferencedInScenes: 0
         m_IncludeAssetsByLabel: 0
         m_LabelToInclude: 
-    - rid: 1932564762852327516
+    - rid: 1932564762852327528
       type: {class: ProbeVolumeBakingResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -180,7 +180,7 @@ MonoBehaviour:
         skyOcclusionRT: {fileID: -5126288278712620388, guid: 5a2a534753fbdb44e96c3c78b5a6999d, type: 3}
         renderingLayerCS: {fileID: -6772857160820960102, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
         renderingLayerRT: {fileID: -5126288278712620388, guid: 94a070d33e408384bafc1dea4a565df9, type: 3}
-    - rid: 1932564762852327517
+    - rid: 1932564762852327529
       type: {class: ProbeVolumeDebugResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1
@@ -190,13 +190,13 @@ MonoBehaviour:
         probeVolumeOffsetDebugShader: {fileID: 4800000, guid: db8bd7436dc2c5f4c92655307d198381, type: 3}
         probeSamplingDebugMesh: {fileID: -3555484719484374845, guid: 20be25aac4e22ee49a7db76fb3df6de2, type: 3}
         numbersDisplayTex: {fileID: 2800000, guid: 73fe53b428c5b3440b7e87ee830b608a, type: 3}
-    - rid: 1932564762852327518
+    - rid: 1932564762852327530
       type: {class: STP/RuntimeResources, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_setupCS: {fileID: 7200000, guid: 33be2e9a5506b2843bdb2bdff9cad5e1, type: 3}
         m_preTaaCS: {fileID: 7200000, guid: a679dba8ec4d9ce45884a270b0e22dda, type: 3}
         m_taaCS: {fileID: 7200000, guid: 3923900e2b41b5e47bc25bfdcbcdc9e6, type: 3}
-    - rid: 1932564762852327519
+    - rid: 1932564762852327531
       type: {class: ProbeVolumeGlobalSettings, ns: UnityEngine.Rendering, asm: Unity.RenderPipelines.Core.Runtime}
       data:
         m_Version: 1


### PR DESCRIPTION
[![UNITY-158](https://badgen.net/badge/JIRA/UNITY-158/0052CC)](https://mcrs.atlassian.net/browse/UNITY-158) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

시간초과와 동시에 타패할 경우 타패와 시간초과로 인한 쯔모기리가 동시 적용되는 버그가 있었습니다.
action id 기반으로 timeout시 강제 타패 메세지가 전송되고 나서 action id가 증가하는것을 이용하여 플레이어의 타패 action을 받았을 때 action_id가 현재 acition_id와 다르다면 무시하는 방식으로 처리하였습니다.

[![GAME-87](https://badgen.net/badge/JIRA/GAME-87/0052CC)](https://mcrs.atlassian.net/browse/GAME-87) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->과 함께 처리하였습니다.

[UNITY-158]: https://mcrs.atlassian.net/browse/UNITY-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GAME-87]: https://mcrs.atlassian.net/browse/GAME-87?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ