### PR TITLE
UNITY-189 add refernce seat and change view seat method

### DIFF
--- a/Assets/Scripts/Game/CenterHoverDisplay.cs
+++ b/Assets/Scripts/Game/CenterHoverDisplay.cs
@@ -115,7 +115,7 @@ namespace MCRGame.Game
             {
                 if (txt == null) continue;
 
-                AbsoluteSeat abs = rel.ToAbsoluteSeat(gm.MySeat);
+                AbsoluteSeat abs = rel.ToAbsoluteSeat(gm.ReferenceSeat);
                 if (!gm.seatToPlayerIndex.TryGetValue(abs, out int idx)
                     || idx < 0 || idx >= gm.Players.Count)
                 {

--- a/Assets/Scripts/Game/EmojiPanelController.cs
+++ b/Assets/Scripts/Game/EmojiPanelController.cs
@@ -132,7 +132,7 @@ namespace MCRGame.Game
 
             // 2) 절대좌석 → 내 기준 상대좌석으로 변환
             var relative = RelativeSeatExtensions.CreateFromAbsoluteSeats(
-                currentSeat: GameManager.Instance.MySeat,
+                currentSeat: GameManager.Instance.ReferenceSeat,
                 targetSeat: seat
             );
 

--- a/Assets/Scripts/Game/FlowerReplacementController.cs
+++ b/Assets/Scripts/Game/FlowerReplacementController.cs
@@ -119,7 +119,7 @@ namespace MCRGame.Game
                 }
 
                 Debug.Log($"[FR]   Seat {abs} → {cnt} flower(s)");
-                RelativeSeat rel = RelativeSeatExtensions.CreateFromAbsoluteSeats(gm.MySeat, abs);
+                RelativeSeat rel = RelativeSeatExtensions.CreateFromAbsoluteSeats(gm.ReferenceSeat, abs);
 
                 for (int i = 0; i < cnt; ++i)
                 {

--- a/Assets/Scripts/Game/GameManager/GameManager.Animation.cs
+++ b/Assets/Scripts/Game/GameManager/GameManager.Animation.cs
@@ -72,7 +72,7 @@ namespace MCRGame.Game
                 if (i == (int)RelativeSeat.SELF) continue;
 
                 RelativeSeat rel = (RelativeSeat)i;
-                AbsoluteSeat abs = rel.ToAbsoluteSeat(MySeat);
+                AbsoluteSeat abs = rel.ToAbsoluteSeat(ReferenceSeat);
 
                 bool includeTsumo = (abs == AbsoluteSeat.EAST);
                 hand3D.InitHand(includeTsumo);

--- a/Assets/Scripts/Game/GameManager/GameManager.RoundInit.cs
+++ b/Assets/Scripts/Game/GameManager/GameManager.RoundInit.cs
@@ -117,8 +117,11 @@ namespace MCRGame.Game
             GetSeatMappings((int)CurrentRound, out seatToPlayerIndex, out playerIndexToSeat);
 
             /* 내 절대좌석 & 현재 턴 좌석 계산 */
-            MySeat = playerIndexToSeat[playerUidToIndex[PlayerDataManager.Instance.Uid]];
-            CurrentTurnSeat = RelativeSeatExtensions.CreateFromAbsoluteSeats(MySeat, AbsoluteSeat.EAST);
+            if (!IsSpectator)
+            {
+                MySeat = playerIndexToSeat[playerUidToIndex[PlayerDataManager.Instance.Uid]];
+            }
+            CurrentTurnSeat = RelativeSeatExtensions.CreateFromAbsoluteSeats(ReferenceSeat, AbsoluteSeat.EAST);
         }
 
         #endregion

--- a/Assets/Scripts/Game/GameManager/GameManager.UI.cs
+++ b/Assets/Scripts/Game/GameManager/GameManager.UI.cs
@@ -179,7 +179,7 @@ namespace MCRGame.Game
             for (int i=0;i<4;i++)
             {
                 RelativeSeat rel = (RelativeSeat)i;
-                AbsoluteSeat abs = rel.ToAbsoluteSeat(MySeat);
+                AbsoluteSeat abs = rel.ToAbsoluteSeat(ReferenceSeat);
 
                 if (!seatToPlayerIndex.TryGetValue(abs,out int pIdx) || pIdx<0 || pIdx>=Players.Count) continue;
                 var player = Players[pIdx];
@@ -228,7 +228,7 @@ namespace MCRGame.Game
             foreach (var (rel,txt) in map)
             {
                 if (!txt) continue;
-                var abs = rel.ToAbsoluteSeat(MySeat);
+                var abs = rel.ToAbsoluteSeat(ReferenceSeat);
                 if (!seatToPlayerIndex.TryGetValue(abs,out int idx) || idx<0 || idx>=Players.Count) continue;
 
                 int s = Players[idx].Score;
@@ -248,7 +248,7 @@ namespace MCRGame.Game
                 {RelativeSeat.KAMI,windText_Kami}
             };
 
-            AbsoluteSeat seat = MySeat;
+            AbsoluteSeat seat = ReferenceSeat;
             for (RelativeSeat rel = RelativeSeat.SELF;; rel = rel.NextSeat())
             {
                 if (map.TryGetValue(rel,out var t) && t)

--- a/Assets/Scripts/UI/GamePage/DiscardManager.cs
+++ b/Assets/Scripts/UI/GamePage/DiscardManager.cs
@@ -146,7 +146,7 @@ namespace MCRGame.UI
                 if (seatIdx < 0 || seatIdx >= allTilesBySeat.Count)
                     continue;
 
-                var tiles = allTilesBySeat[(int)RelativeSeatExtensions.ToAbsoluteSeat(rel: seat, mySeat: GameManager.Instance.MySeat)];
+                var tiles = allTilesBySeat[(int)RelativeSeatExtensions.ToAbsoluteSeat(rel: seat, mySeat: GameManager.Instance.ReferenceSeat)];
                 Transform origin = GetDiscardPosition(seat);
                 if (origin == null)
                 {


### PR DESCRIPTION
[![UNITY-189](https://badgen.net/badge/JIRA/UNITY-189/0052CC)](https://mcrs.atlassian.net/browse/UNITY-189) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=MCRMasters&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

RefernceSeat을 기반으로 view seat을 바꾸는 method를 추가하였습니다.

RefernceSeat은 상대 좌표를 계산하는 기준이 되는 절대 좌표로, 일반적인 플레이 상황에서는 MySeat이며, 관전상황에는 ViewSeat이 됩니다.

ViewSeat이 변하면 그에 따라 ChangeViewSeat함수를 실행하여 새로운 ReferenceSeat에 따른 상대 좌표에 대한 정보를 전부 다 재계산해야합니다.

[UNITY-189]: https://mcrs.atlassian.net/browse/UNITY-189?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ